### PR TITLE
feat: Remove Jupyter bindings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,6 @@
     "author": {
         "name": "Deepnote"
     },
-    "extensionPack": [
-        "ms-toolsai.jupyter-keymap",
-        "ms-toolsai.jupyter-renderers",
-        "ms-toolsai.vscode-jupyter-slideshow",
-        "ms-toolsai.vscode-jupyter-cell-tags"
-    ],
     "license": "MIT",
     "homepage": "https://github.com/deepnote/vscode-deepnote",
     "repository": {
@@ -54,16 +48,12 @@
         "Visualization"
     ],
     "activationEvents": [
-        "onLanguage:jupyter",
         "onLanguage:python",
         "onLanguageModelTool:configure_notebook",
         "onLanguageModelTool:notebook_install_packages",
         "onLanguageModelTool:notebook_list_packages",
         "onNotebook:deepnote",
-        "onNotebook:interactive",
-        "onNotebook:jupyter-notebook",
-        "onWebviewPanel:jupyter-variables",
-        "onWebviewPanel:jupyter"
+        "onNotebook:interactive"
     ],
     "main": "./dist/extension.node.proxy.js",
     "browser": "./dist/extension.web.bundle.js",
@@ -75,179 +65,11 @@
         }
     },
     "contributes": {
-        "walkthroughs": [
-            {
-                "id": "jupyterWelcome",
-                "title": "%contributes.walkthroughs.jupyterWelcome.title%",
-                "description": "%contributes.walkthroughs.jupyterWelcome.description%",
-                "when": "workspacePlatform != webworker",
-                "steps": [
-                    {
-                        "id": "ipynb.newUntitledIpynb",
-                        "title": "%contributes.walkthroughs.jupyterWelcome.steps.ipynb.newUntitledIpynb.title%",
-                        "description": "%contributes.walkthroughs.jupyterWelcome.steps.ipynb.newUntitledIpynb.description%",
-                        "media": {
-                            "svg": "resources/walkthroughs/opennotebook.svg",
-                            "altText": "%contributes.walkthroughs.jupyterWelcome.steps.ipynb.newUntitledIpynb.media.altText%"
-                        },
-                        "completionEvents": [
-                            "onCommand:ipynb.newUntitledIpynb",
-                            "onCommand:jupyter.createnewinteractive",
-                            "onCommand:workbench.action.files.openFolder",
-                            "onCommand:workbench.action.files.openFileFolder"
-                        ]
-                    },
-                    {
-                        "id": "jupyter.selectKernel",
-                        "title": "%contributes.walkthroughs.jupyterWelcome.steps.jupyter.selectKernel.title%",
-                        "description": "%contributes.walkthroughs.jupyterWelcome.steps.jupyter.selectKernel.description%",
-                        "media": {
-                            "svg": "resources/walkthroughs/kernel.svg",
-                            "altText": "%contributes.walkthroughs.jupyterWelcome.steps.jupyter.selectKernel.media.altText%"
-                        },
-                        "completionEvents": [
-                            "onCommand:notebook.selectKernel"
-                        ]
-                    },
-                    {
-                        "id": "jupyter.exploreAndDebug",
-                        "title": "%contributes.walkthroughs.jupyterWelcome.steps.jupyter.exploreAndDebug.title%",
-                        "description": "%contributes.walkthroughs.jupyterWelcome.steps.jupyter.exploreAndDebug.description%",
-                        "media": {
-                            "svg": "resources/walkthroughs/data.svg",
-                            "altText": "%contributes.walkthroughs.jupyterWelcome.steps.jupyter.exploreAndDebug.media.altText%"
-                        }
-                    },
-                    {
-                        "id": "jupyter.dataScienceLearnMore",
-                        "title": "%contributes.walkthroughs.jupyterWelcome.steps.jupyter.dataScienceLearnMore.title%",
-                        "description": "%contributes.walkthroughs.jupyterWelcome.steps.jupyter.dataScienceLearnMore.description%",
-                        "media": {
-                            "svg": "resources/walkthroughs/learnmore.svg",
-                            "altText": "%contributes.walkthroughs.jupyterWelcome.steps.jupyter.dataScienceLearnMore.media.altText%"
-                        }
-                    }
-                ]
-            }
-        ],
         "keybindings": [
-            {
-                "command": "jupyter.execSelectionInteractive",
-                "key": "shift+enter",
-                "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && jupyter.ownsSelection && !notebookEditorFocused && !isCompositeNotebook"
-            },
-            {
-                "command": "jupyter.runcurrentcelladvance",
-                "key": "shift+enter",
-                "when": "editorTextFocus && !editorHasSelection && jupyter.hascodecells && !notebookEditorFocused && !isCompositeNotebook"
-            },
-            {
-                "command": "jupyter.runcurrentcell",
-                "key": "ctrl+enter",
-                "when": "editorTextFocus && !editorHasSelection && jupyter.hascodecells && !notebookEditorFocused && !isCompositeNotebook"
-            },
-            {
-                "command": "jupyter.runcurrentcellandaddbelow",
-                "key": "alt+enter",
-                "when": "editorTextFocus && !editorHasSelection && jupyter.hascodecells && !notebookEditorFocused"
-            },
             {
                 "key": "escape",
                 "when": "isCompositeNotebook && !editorHoverVisible && !suggestWidgetVisible && !isComposing && !inSnippetMode && !exceptionWidgetVisible && !selectionAnchorSet && !LinkedEditingInputVisible && !renameInputVisible && !editorHasSelection && !accessibilityHelpWidgetVisible && !breakpointWidgetVisible && !findWidgetVisible && !markersNavigationVisible && !parameterHintsVisible && !editorHasMultipleSelections && !notificationToastsVisible && !notebookEditorFocused && !inlineChatVisible",
                 "command": "interactive.input.clear"
-            },
-            {
-                "command": "jupyter.insertCellBelowPosition",
-                "key": "ctrl+; s",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.insertCellBelow",
-                "key": "ctrl+; b",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.insertCellAbove",
-                "key": "ctrl+; a",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.deleteCells",
-                "key": "ctrl+; x",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.extendSelectionByCellAbove",
-                "key": "ctrl+alt+shift+[",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.extendSelectionByCellBelow",
-                "key": "ctrl+alt+shift+]",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.moveCellsUp",
-                "key": "ctrl+; u",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.moveCellsDown",
-                "key": "ctrl+; d",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.changeCellToMarkdown",
-                "key": "ctrl+; m",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.changeCellToCode",
-                "key": "ctrl+; c",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.gotoNextCellInFile",
-                "key": "ctrl+alt+]",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.gotoPrevCellInFile",
-                "key": "ctrl+alt+[",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.selectCellContents",
-                "key": "ctrl+alt+\\",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.selectCell",
-                "key": "ctrl+alt+shift+\\",
-                "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"
-            },
-            {
-                "command": "jupyter.refreshDataViewer",
-                "key": "ctrl+r",
-                "mac": "cmd+r",
-                "when": "jupyter.dataViewerActive"
-            },
-            {
-                "command": "jupyter.runAndDebugCell",
-                "key": "ctrl+alt+shift+enter",
-                "mac": "ctrl+shift+enter"
-            },
-            {
-                "command": "jupyter.runByLine",
-                "key": "f10"
-            },
-            {
-                "command": "jupyter.runByLineNext",
-                "key": "f10"
-            },
-            {
-                "command": "jupyter.runByLineStop",
-                "key": "ctrl+enter"
             }
         ],
         "commands": [
@@ -1414,7 +1236,7 @@
         },
         "configuration": {
             "type": "object",
-            "title": "Jupyter",
+            "title": "Deepnote",
             "properties": {
                 "jupyter.experiments.enabled": {
                     "type": "boolean",
@@ -1973,13 +1795,6 @@
         ],
         "notebookPreload": [
             {
-                "type": "jupyter-notebook",
-                "localResourceRoots": [
-                    "./temp"
-                ],
-                "entrypoint": "./dist/webviews/webview-side/ipywidgetsKernel/ipywidgetsKernel.js"
-            },
-            {
                 "type": "deepnote",
                 "localResourceRoots": [
                     "./temp"
@@ -1994,35 +1809,12 @@
                 "entrypoint": "./dist/webviews/webview-side/ipywidgetsKernel/ipywidgetsKernel.js"
             }
         ],
-        "notebookRenderer": [
-            {
-                "id": "jupyter-ipywidget-renderer",
-                "entrypoint": "./dist/webviews/webview-side/ipywidgetsRenderer/ipywidgetsRenderer.js",
-                "displayName": "%jupyter.notebookRenderer.IPyWidget.displayName%",
-                "mimeTypes": [
-                    "application/vnd.jupyter.widget-view+json"
-                ],
-                "requiresMessaging": "always"
-            }
-        ],
         "viewsContainers": {
             "activitybar": [
-                {
-                    "id": "jupyter",
-                    "title": "Jupyter",
-                    "icon": "$(notebook)"
-                },
                 {
                     "id": "deepnote",
                     "title": "Deepnote",
                     "icon": "resources/DnDeepnoteLineLogo.svg"
-                }
-            ],
-            "panel": [
-                {
-                    "id": "jupyter-variables",
-                    "title": "Jupyter",
-                    "icon": "$(notebook)"
                 }
             ]
         },


### PR DESCRIPTION
Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed Jupyter UI surfaces (activity bar, variables panel) and notebook renderer; extension now focuses on Deepnote and Interactive notebooks.
  - Dropped Jupyter notebook preload; retained Deepnote and Interactive preloads.
  - Reduced activation events to Python, notebook tools, Deepnote, and Interactive.
  - Simplified keybindings, keeping only Escape for interactive input.
  - Renamed configuration titles from “Jupyter” to “Deepnote”.
- Documentation
  - Removed walkthroughs related to Jupyter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->