### PR TITLE
ci: license checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-        
+
       - name: Check Licenses
         run: npm run check-licenses

--- a/package.json
+++ b/package.json
@@ -2055,7 +2055,7 @@
         "build:prerelease": "cross-env IS_PRE_RELEASE_VERSION_OF_JUPYTER_EXTENSION=true npm run build",
         "build:stable": "cross-env IS_PRE_RELEASE_VERSION_OF_JUPYTER_EXTENSION=false npm run build",
         "build": "concurrently npm:compile-release npm:updatePackageJsonForBundle",
-        "check-licenses": "npx license-checker-rseidelsohn --onlyAllow 'MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause;0BSD;Python-2.0;CC0-1.0;CC-BY-3.0;CC-BY-4.0;Unlicense;BlueOak-1.0.0;MPL-2.0' --excludePrivatePackages --excludePackages 'bootstrap-less@3.3.8'",
+        "check-licenses": "npx license-checker-rseidelsohn --onlyAllow 'MIT;Apache-2.0;Apache v2;ISC;BSD;BSD-2-Clause;BSD-3-Clause;0BSD;Python-2.0;CC0-1.0;CC-BY-3.0;CC-BY-4.0;Unlicense;BlueOak-1.0.0;MPL-2.0' --excludePrivatePackages --excludePackages 'bootstrap-less@3.3.8;chai-as-promised@7.1.1;esbuild-plugin-less@1.3.19;eslint-plugin-local-rules@1.0.0;truncate-utf8-bytes@1.0.2;utf8-byte-length@1.0.4'",
         "checkDependencies": "gulp checkDependencies",
         "clean": "gulp clean",
         "compile-esbuild-watch": "npx tsx build/esbuild/build.ts --watch",


### PR DESCRIPTION
Fixes [OSS-107](https://linear.app/deepnote/issue/OSS-107/add-a-license)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Added an automated license compliance check to CI, adding a dedicated license-check job and a CI step to run license auditing so build runs surface disallowed or unapproved dependencies.
  * Added a local npm script to audit third‑party licenses against an approved list (excluding private packages and specified exceptions) to ensure consistent local and CI license reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->