### PR TITLE
feat: Ensure Toolkit doesn't connect to Deepnote backend (webapp)

### DIFF
--- a/src/kernels/deepnote/deepnoteServerStarter.node.ts
+++ b/src/kernels/deepnote/deepnoteServerStarter.node.ts
@@ -147,6 +147,12 @@ export class DeepnoteServerStarter implements IDeepnoteServerStarter, IExtension
         // Enforce published pip constraints to prevent breaking Deepnote Toolkit's dependencies
         env.DEEPNOTE_ENFORCE_PIP_CONSTRAINTS = 'true';
 
+        // Detached mode ensures no requests are made to the backend (directly, or via proxy)
+        // as there is no backend running in the extension, therefore:
+        // 1. integration environment variables won't work / be injected
+        // 2. post start hooks won't work / are not executed
+        env.DEEPNOTE_RUNTIME__RUNNING_IN_DETACHED_MODE = 'true';
+
         // Remove PYTHONHOME if it exists (can interfere with venv)
         delete env.PYTHONHOME;
 


### PR DESCRIPTION
closes BLU-4936


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a detached server startup mode that runs fully isolated without contacting backend services.
  - Disables automatic integration environment variable injection and post-start hooks when detached.
  - Preserves existing startup behavior (environment setup, dependency constraints, working directory, server launch, lock handling, timeouts) outside of the detached mode.
  - Ideal for offline or sandboxed sessions where external connectivity and automations should be suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->