### PR TITLE
fix: Install kernel spec into venv instead of user directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 ## Code Style & Organization
 - Order method, fields and properties, first by accessibility and then by alphabetical order.
 - Don't add the Microsoft copyright header to new files.
+- Use `Uri.joinPath()` for constructing file paths to ensure platform-correct path separators (e.g., `Uri.joinPath(venvPath, 'share', 'jupyter', 'kernels')` instead of string concatenation with `/`)
 
 ## Testing
 - Unit tests use Mocha/Chai framework with `.unit.test.ts` extension

--- a/src/kernels/deepnote/deepnoteToolkitInstaller.node.ts
+++ b/src/kernels/deepnote/deepnoteToolkitInstaller.node.ts
@@ -65,7 +65,7 @@ export class DeepnoteToolkitInstaller implements IDeepnoteToolkitInstaller {
         const venvPath = this.getVenvPath(deepnoteFileUri);
         const venvKey = venvPath.fsPath;
 
-        logger.info(`Virtual environment at ${venvKey}.`);
+        logger.info(`Ensuring virtual environment at ${venvKey}`);
 
         // Wait for any pending installation for this venv to complete
         const pendingInstall = this.pendingInstallations.get(venvKey);
@@ -231,11 +231,14 @@ export class DeepnoteToolkitInstaller implements IDeepnoteToolkitInstaller {
                         ],
                         { throwOnStdErr: false }
                     );
-                    logger.info(
-                        `Kernel spec installed successfully to ${
-                            venvPath.fsPath
-                        }/share/jupyter/kernels/deepnote-venv-${this.getVenvHash(deepnoteFileUri)}`
+                    const kernelSpecPath = Uri.joinPath(
+                        venvPath,
+                        'share',
+                        'jupyter',
+                        'kernels',
+                        `deepnote-venv-${this.getVenvHash(deepnoteFileUri)}`
                     );
+                    logger.info(`Kernel spec installed successfully to ${kernelSpecPath.fsPath}`);
                 } catch (ex) {
                     logger.warn(`Failed to install kernel spec: ${ex}`);
                     // Don't fail the entire installation if kernel spec creation fails


### PR DESCRIPTION
Previously, ipykernel specs were installed with --user flag, placing them in ~/Library/Jupyter/kernels/. This caused the Deepnote Jupyter server to fall back to generic Python kernels because it was unable to discover the venv-specific kernel spec.

This resulted in a mismatch where:
- Shell commands (!pip install) used the venv's Python (via PATH)
- But the kernel interpreter used the system Python
- Leading to ModuleNotFoundError for packages installed in the venv

Now installing kernel specs with --prefix into the venv itself at <venv>/share/jupyter/kernels/. Jupyter automatically discovers kernel specs in this location when started with the venv's Python, ensuring the correct interpreter is used.

Each .deepnote file maintains its own isolated venv with its own kernel spec, preventing conflicts when multiple notebooks are open.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kernel installation now targets the selected virtual environment and waits/retries for any pending or failed installations to avoid conflicts.

* **Chores**
  * Improved runtime logging: shows virtual environment path at start, notes when waiting for other installs, and reports the exact kernel spec destination; existing error handling unchanged.

* **Documentation**
  * Added guidance to use Uri.joinPath() for platform-correct file path construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->