### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repository
+* @saltenasl @jamesbhobbs @Artmann @andyjakubowski


### PR DESCRIPTION
## Summary

Adds a CODEOWNERS file to establish default code ownership for the repository, copied from the deepnote/deepnote repository configuration.

## Changes

- **New CODEOWNERS file** (`.github/CODEOWNERS`): Sets @saltenasl @jamesbhobbs @Artmann @andyjakubowski as default owners for all files (`*`)

## Human Review Checklist

- [ ] Verify all GitHub usernames are correct and users exist
- [ ] Confirm these users have appropriate repository access permissions  
- [ ] Validate that giving ownership over all files (`*`) is the intended scope
- [ ] Test that GitHub properly recognizes the CODEOWNERS file format

## Notes

This change mirrors the CODEOWNERS setup from the main deepnote/deepnote repository to maintain consistent ownership patterns across Deepnote extension repositories.

---

**Link to Devin run:** https://app.devin.ai/sessions/7df2a76e10f2447faf46c3c41fd5cc8c  
**Requested by:** @jamesbhobbs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Introduced repository code ownership rules to automatically assign default reviewers for any changes, streamlining code reviews and improving accountability across the project. This applies to all areas of the repository. There are no user-facing changes and no impact on runtime behavior, performance, or UI. Development workflow is improved through clearer ownership and faster reviewer assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->