### PR TITLE
chore: Bump toolkit version to latest

### DIFF
--- a/src/kernels/deepnote/types.ts
+++ b/src/kernels/deepnote/types.ts
@@ -154,7 +154,7 @@ export interface IDeepnoteKernelAutoSelector {
     ensureKernelSelected(notebook: vscode.NotebookDocument, token?: vscode.CancellationToken): Promise<void>;
 }
 
-export const DEEPNOTE_TOOLKIT_VERSION = '0.2.30.post23';
+export const DEEPNOTE_TOOLKIT_VERSION = '0.2.30.post30';
 export const DEEPNOTE_TOOLKIT_WHEEL_URL = `https://deepnote-staging-runtime-artifactory.s3.amazonaws.com/deepnote-toolkit-packages/${DEEPNOTE_TOOLKIT_VERSION}/deepnote_toolkit-${DEEPNOTE_TOOLKIT_VERSION}-py3-none-any.whl`;
 export const DEEPNOTE_DEFAULT_PORT = 8888;
 export const DEEPNOTE_NOTEBOOK_TYPE = 'deepnote';


### PR DESCRIPTION
Bumps to latest toolkit, which includes fixes for issues during package installation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Deepnote toolkit version to 0.2.30.post30. This ensures the application references the latest toolkit build and uses the corresponding wheel download URL during setup. No user interface or workflow changes are introduced. This is a background update aimed at keeping the environment aligned with the most recent toolkit release for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->