### PR TITLE
fix: update Playwright to 1.56.1 to resolve security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16003,13 +16003,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.54.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
-            "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+            "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.54.1"
+                "playwright-core": "1.56.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -16047,6 +16047,19 @@
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/playwright/node_modules/playwright-core": {
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+            "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/plugin-error": {
@@ -32149,13 +32162,13 @@
             }
         },
         "playwright": {
-            "version": "1.54.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
-            "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+            "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
             "dev": true,
             "requires": {
                 "fsevents": "2.3.2",
-                "playwright-core": "1.54.1"
+                "playwright-core": "1.56.1"
             },
             "dependencies": {
                 "fsevents": {
@@ -32164,6 +32177,12 @@
                     "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
                     "dev": true,
                     "optional": true
+                },
+                "playwright-core": {
+                    "version": "1.56.1",
+                    "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+                    "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+                    "dev": true
                 }
             }
         },


### PR DESCRIPTION
## Summary

Updates Playwright from 1.54.1 to 1.56.1 to fix moderate severity vulnerability [GHSA-7mvr-c777-76hp](https://github.com/advisories/GHSA-7mvr-c777-76hp), where Playwright downloads and installs browsers without verifying SSL certificate authenticity.

## Changes

- Updated `playwright` and `playwright-core` from 1.54.1 to 1.56.1 in package-lock.json
- Fix applied via `npm audit fix`

## Testing

- ✅ All unit tests pass (1415 passing)
- ✅ Lint checks pass
- ✅ Format checks pass

## Review Checklist

- [ ] Verify version bump correctly addresses GHSA-7mvr-c777-76hp
- [ ] Confirm no unexpected changes in package-lock.json
- [ ] Consider running integration tests that use Playwright if available

---

**Link to Devin run**: https://app.devin.ai/sessions/cd8da455c70c4cd797da66b575182718  
**Requested by**: James Hobbs (james@deepnote.com) @jamesbhobbs