### PR TITLE
Remove andyjakubowski from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for everything in the repository
-* @saltenasl @jamesbhobbs @Artmann @andyjakubowski
+* @saltenasl @jamesbhobbs @Artmann


### PR DESCRIPTION
# Remove andyjakubowski from CODEOWNERS

## Summary
Removes `@andyjakubowski` from the default code owners list for the vscode-deepnote repository. This user will no longer be automatically requested for code reviews on pull requests.

This change is part of a broader cleanup to remove this user from CODEOWNERS across multiple Deepnote repositories (jupyterlab-deepnote, deepnote, vscode-deepnote, and deepnote-internal).

## Changes
- Updated `.github/CODEOWNERS` to remove `@andyjakubowski` from the default owners line
- Remaining owners: @saltenasl, @jamesbhobbs, @Artmann

## Review Checklist
- [ ] Verify that removing @andyjakubowski from CODEOWNERS is authorized
- [ ] Confirm that the remaining code owners (@saltenasl, @jamesbhobbs, @Artmann) provide adequate review coverage for this repository

---

**Link to Devin run:** https://app.devin.ai/sessions/5a8f5921776546b797c99b41edeb78bb  
**Requested by:** James Hobbs (james@deepnote.com) - @jamesbhobbs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default code owners configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->