### PR TITLE
ci: add fetch-depth: 0 to qlty checkout for proper git history access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          fetch-depth: 0
 
       - name: Install qlty
         uses: qltysh/qlty-action/install@6bbb1add7432c45a3fd35a824ea69dc5bef27967


### PR DESCRIPTION
## Summary

This PR updates the qlty job in the CI workflow to fetch full git history by adding `fetch-depth: 0` to the checkout action. This ensures qlty has access to the complete git history, which is required for it to properly analyze code changes and compare against previous commits/branches.

## Changes

- **`.github/workflows/ci.yml`**: 
  - Added `fetch-depth: 0` to the checkout step in the qlty job
  - Updated checkout action to v5 (standardizing with the pinned SHA)

## Why This Change?

By default, `actions/checkout` performs a shallow clone with limited history. Qlty relies on having access to the full git history to:
- Compare code against the base branch
- Detect changes accurately
- Provide meaningful code quality feedback

Without `fetch-depth: 0`, qlty may produce inaccurate results or fail to detect changes properly.

## Testing

⚠️ This change can only be validated through CI runs. Please verify:
- All CI checks pass
- Qlty check and qlty smells jobs complete successfully
- No significant increase in CI duration

## Related

This is part of a broader effort to standardize qlty checkout configuration across all Deepnote repositories (jupyterlab-deepnote, deepnote, deepnote-internal, vscode-deepnote).

---

**Link to Devin run:** https://app.devin.ai/sessions/8e83a17c48d34c79be89b985c9b936ee  
**Requested by:** James Hobbs (james@deepnote.com) / @jamesbhobbs