### PR TITLE
chore: add biome formatter configuration

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,33 +1,33 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
-  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-  "files": { "ignoreUnknown": false },
-  "formatter": {
-    "enabled": true,
-    "formatWithErrors": false,
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineEnding": "lf",
-    "lineWidth": 120,
-    "attributePosition": "auto",
-    "bracketSameLine": false,
-    "bracketSpacing": true,
-    "expand": "auto",
-    "useEditorconfig": true,
-    "includes": ["**", "!./coverage", "!./dist", "!**/package.json"]
-  },
-  "javascript": {
+    "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
+    "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+    "files": { "ignoreUnknown": false },
     "formatter": {
-      "jsxQuoteStyle": "single",
-      "quoteProperties": "preserve",
-      "trailingCommas": "es5",
-      "semicolons": "asNeeded",
-      "arrowParentheses": "asNeeded",
-      "bracketSameLine": false,
-      "quoteStyle": "single",
-      "attributePosition": "auto",
-      "bracketSpacing": true
-    }
-  },
-  "html": { "formatter": { "selfCloseVoidElements": "always" } }
+        "enabled": true,
+        "formatWithErrors": false,
+        "indentStyle": "space",
+        "indentWidth": 2,
+        "lineEnding": "lf",
+        "lineWidth": 120,
+        "attributePosition": "auto",
+        "bracketSameLine": false,
+        "bracketSpacing": true,
+        "expand": "auto",
+        "useEditorconfig": true,
+        "includes": ["**", "!./coverage", "!./dist", "!**/package.json"]
+    },
+    "javascript": {
+        "formatter": {
+            "jsxQuoteStyle": "single",
+            "quoteProperties": "preserve",
+            "trailingCommas": "es5",
+            "semicolons": "asNeeded",
+            "arrowParentheses": "asNeeded",
+            "bracketSameLine": false,
+            "quoteStyle": "single",
+            "attributePosition": "auto",
+            "bracketSpacing": true
+        }
+    },
+    "html": { "formatter": { "selfCloseVoidElements": "always" } }
 }


### PR DESCRIPTION
## Summary

Adds Biome formatter configuration file to enable opt-in usage of Biome as an alternative to Prettier. This is a configuration-only change that does not install Biome as a dependency or integrate it into the build process.

Configuration copied from `deepnote/deepnote` OSS repository to maintain consistency across Deepnote projects.

## Changes

- Added `biome.json` with formatter-only configuration:
  - 2-space indentation, 120 character line width
  - Single quotes, semicolons as needed
  - Respects `.editorconfig` files if present
  - Excludes `package.json`, `coverage`, and `dist` from formatting
  - JavaScript/TypeScript/HTML formatting rules

## Review Checklist

- [ ] **Formatter settings** - Verify the configuration matches project standards (particularly line width: 120, indent: 2 spaces, quotes: single)
- [ ] **Integration approach** - Confirm that config-only (no package installation) is the desired approach vs. full Biome integration
- [ ] **Future steps** - Consider if follow-up work is needed to:
  - Add Biome as devDependency
  - Update npm scripts to support Biome formatting
  - Document how developers can opt-in to using Biome

## Notes

- This PR intentionally does NOT install Biome as a dependency - developers who want to use Biome will need to install it separately
- Existing Prettier + ESLint setup remains unchanged and will continue to be enforced by CI
- The `biome.json` file was formatted with Prettier to pass existing CI checks

---

**Link to Devin run:** https://app.devin.ai/sessions/df9fb4f9ff664ab28848f60fedcb2877  
**Requested by:** James Hobbs (james@deepnote.com) / @jamesbhobbs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project tooling configuration to standardize code formatting and linting standards across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->