### PR TITLE
chore: add draftPR to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "configMigration": true,
+    "draftPR": true,
     "enabledManagers": ["npm", "nvm", "github-actions"],
     "github-actions": {
         "enabled": true,


### PR DESCRIPTION
## Summary

Adds `"draftPR": true` to the Renovate configuration, causing all future dependency update PRs created by Renovate bot to be opened as drafts instead of immediately ready for review.

This is a one-line configuration change requested by James Hobbs (@jamesbhobbs) and applied consistently across 6 Deepnote repositories.

## Changes

- Added `"draftPR": true` to `renovate.json` after `configMigration` field
- No other configuration options were modified

## Review & Testing Checklist

- [ ] **Confirm draft PR behavior is desired**: Verify that having all Renovate PRs created as drafts (requiring manual "Ready for review" action) is the intended workflow for vscode-deepnote
- [ ] **JSON syntax validation**: The comma placement and JSON structure are correct
- [ ] **Configuration placement**: The field is appropriately positioned in the config object

**Link to Devin run:** https://app.devin.ai/sessions/39ddd2987cd74590bdd9f562103987e3  
**Requested by:** James Hobbs (james@deepnote.com) / @jamesbhobbs