### PR TITLE
feat: Delete python virtual environment directory when removing deepnote environment

### DIFF
--- a/src/kernels/deepnote/environments/deepnoteEnvironmentManager.node.ts
+++ b/src/kernels/deepnote/environments/deepnoteEnvironmentManager.node.ts
@@ -208,6 +208,10 @@ export class DeepnoteEnvironmentManager implements IExtensionSyncActivationServi
         } catch (error) {
             // Log but don't fail - the directory might not exist or might already be deleted
             logger.warn(`Failed to delete virtual environment directory: ${config.venvPath.fsPath}`, error);
+            const msg = error instanceof Error ? error.message : String(error);
+            this.outputChannel.appendLine(
+                l10n.t('Failed to delete Deepnote virtual environment directory for "{0}": {1}', config.name, msg)
+            );
         }
 
         Cancellation.throwIfCanceled(token);

--- a/src/kernels/deepnote/environments/deepnoteEnvironmentManager.unit.test.ts
+++ b/src/kernels/deepnote/environments/deepnoteEnvironmentManager.unit.test.ts
@@ -284,8 +284,7 @@ suite('DeepnoteEnvironmentManager', () => {
             // Delete the environment
             await manager.deleteEnvironment(config.id);
 
-            // Verify directory no longer exists (with a small delay to allow async operation)
-            await new Promise((resolve) => setTimeout(resolve, 100));
+            // Verify directory no longer exists
             assert.isFalse(fs.existsSync(venvDirPath), 'Directory should not exist after deletion');
         });
     });


### PR DESCRIPTION
Signed-off-by: Tomas Kislan <tomas@kislan.sk>

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual environment directories are now removed from disk when an environment is deleted.
  * Cancellation handling during environment cleanup is improved to avoid unexpected failures.
  * Deletion errors are logged and surfaced to the output without disrupting the overall flow.

* **Tests**
  * Added tests that verify on-disk cleanup and proper teardown of temporary storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->