### PR TITLE
fix: NaN rows in dataframe output renderer

### DIFF
--- a/src/webviews/extension-side/dataframe/dataframeController.ts
+++ b/src/webviews/extension-side/dataframe/dataframeController.ts
@@ -47,7 +47,7 @@ interface DataFrameObject {
         dtype: string;
         name: string;
     }[];
-    preview_row_count: number;
+    preview_row_count?: number;
     row_count: number;
     rows: Record<string, unknown>[];
     type: string;

--- a/src/webviews/webview-side/dataframe-renderer/DataframeRenderer.tsx
+++ b/src/webviews/webview-side/dataframe-renderer/DataframeRenderer.tsx
@@ -75,8 +75,7 @@ export const DataframeRenderer = memo(function DataframeRenderer({
     const selectId = useMemo(() => generateUuid(), []);
 
     const filteredColumns = data.columns.filter((column) => !column.name.startsWith('_deepnote_'));
-    const numberOfRows =
-        !data.preview_row_count || Number.isNaN(data.preview_row_count) ? data.row_count : data.preview_row_count;
+    const numberOfRows = Number.isFinite(data.preview_row_count) ? data.preview_row_count : data.row_count;
     const numberOfColumns = filteredColumns.length;
 
     const totalPages = Math.ceil(data.row_count / pageSize);


### PR DESCRIPTION
Open [Snowflake-in-Deepnote.deepnote.txt](https://github.com/user-attachments/files/23283350/Snowflake-in-Deepnote.deepnote.txt)(rm the .txt, github cached this and won't let me re-upload) - the dataframe outputs for the blocks shouldn't say NaN rows (e.g. the one that starts with `SELECT row_number() over (ORDER`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preview row count is now optional: when a preview value is provided it’s used; otherwise the full row count is shown.
  * Improved handling of invalid preview values (e.g., NaN or non-finite values) so they no longer disrupt selection, resulting in more consistent and predictable dataframe previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->