### PR TITLE
fix: Use 'json' as language name when parsing chart block from file

### DIFF
--- a/src/notebooks/deepnote/converters/visualizationBlockConverter.ts
+++ b/src/notebooks/deepnote/converters/visualizationBlockConverter.ts
@@ -84,7 +84,7 @@ export class VisualizationBlockConverter implements BlockConverter {
         };
 
         const jsonContent = JSON.stringify(config, null, 2);
-        const cell = new NotebookCellData(NotebookCellKind.Code, jsonContent, 'JSON');
+        const cell = new NotebookCellData(NotebookCellKind.Code, jsonContent, 'json');
 
         return cell;
     }

--- a/src/notebooks/deepnote/converters/visualizationBlockConverter.unit.test.ts
+++ b/src/notebooks/deepnote/converters/visualizationBlockConverter.unit.test.ts
@@ -59,7 +59,7 @@ suite('VisualizationBlockConverter', () => {
             const cell = converter.convertToCell(block);
 
             assert.strictEqual(cell.kind, NotebookCellKind.Code);
-            assert.strictEqual(cell.languageId, 'JSON');
+            assert.strictEqual(cell.languageId, 'json');
             assert.include(cell.value, '\n');
             assert.match(cell.value, /{\n  "variable"/);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected language identifier formatting for visualization block cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->