### PR TITLE
fix(code-outputs): do not show the panel on load

### DIFF
--- a/src/platform/logging/index.ts
+++ b/src/platform/logging/index.ts
@@ -64,7 +64,6 @@ export function initializeLoggers(options: {
         })
     );
     const standardOutputChannel = window.createOutputChannel(OutputChannelNames.jupyter, 'log');
-    standardOutputChannel.show(true); // Show by default without stealing focus
     registerLogger(new OutputChannelLogger(standardOutputChannel, options?.homePathRegEx, options?.userNameRegEx));
 
     if (options.addConsoleLogger) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Output logging no longer automatically displays on startup, providing a cleaner initial experience while maintaining all logging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->