### PR TITLE
chore(ci): ignore GHSA-73rr-hh4g-fpgx and GHSA-g9mf-h72j-4rw9

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,6 +1,14 @@
 {
+    "GHSA-73rr-hh4g-fpgx": {
+        "notes": "diff DoS via infinite loop when parsing patches with special line break characters. Accepted risk: dev-only dependency (mocha, sinon, tslint), only affects development/CI, not bundled in extension.",
+        "expiry": "2026-04-15"
+    },
     "GHSA-848j-6mx2-7j84": {
         "notes": "CVE-2025-14505: elliptic ECDSA signature corruption can lead to private key recovery if attacker obtains both faulty and correct signatures for identical inputs. Accepted risk: dev-only transitive dependency (node-stdlib-browser -> crypto-browserify -> browserify-sign), not used for signing in this project, no fix available.",
         "expiry": "2026-04-08"
+    },
+    "GHSA-g9mf-h72j-4rw9": {
+        "notes": "undici DoS via unbounded decompression chain. Accepted risk: dev-only transitive dependency (@actions/core, @actions/github), only affects CI/CD workflows, not bundled in extension.",
+        "expiry": "2026-04-15"
     }
 }


### PR DESCRIPTION
Overall Risk: LOW - Both advisories affect dev dependencies only. None of these vulnerable packages are
bundled in the distributed VSCode extension or affect end users.

---
Advisory Analysis

1. GHSA-73rr-hh4g-fpgx (diff/jsdiff) - DoS via infinite loop

Vulnerability: Parsing patches with special line break characters (\r, \u2028, \u2029) in filename headers
causes infinite loop and memory exhaustion.

Attack Surface in This Repo: None for end users
- Used only by test frameworks during development/CI
- Never bundled in the extension
- Would require attacker to inject malicious patch content into test output

Risk Assessment: NEGLIGIBLE

---
2. GHSA-g9mf-h72j-4rw9 (undici) - DoS via compression bomb

Vulnerability: Unbounded decompression chain allows malicious server to cause DoS via excessive CPU/memory
consumption.

Attack Surface in This Repo: None for end users
- Only used by GitHub Actions libraries for CI/CD automation
- Never bundled in the extension
- Would require malicious server to respond to GH Actions HTTP requests

Risk Assessment: NEGLIGIBLE

Both are dev dependencies not bundled in the extension.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security vulnerability configuration with two new entries and associated metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->