### PR TITLE
fix(security): upgrade tar to 7.5.4 for GHSA-r6q2-hw4h-h46w CVE-2026-23950

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28224,9 +28224,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-            "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.4.tgz",
+            "integrity": "sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
@@ -36185,7 +36185,7 @@
                 "@tailwindcss/oxide-win32-arm64-msvc": "4.1.14",
                 "@tailwindcss/oxide-win32-x64-msvc": "4.1.14",
                 "detect-libc": "^2.0.4",
-                "tar": "7.5.3"
+                "tar": "7.5.4"
             }
         },
         "@tailwindcss/oxide-android-arm64": {
@@ -39019,7 +39019,7 @@
                 "promise-inflight": "^1.0.1",
                 "rimraf": "^3.0.2",
                 "ssri": "^8.0.1",
-                "tar": "7.5.3",
+                "tar": "7.5.4",
                 "unique-filename": "^1.1.1"
             },
             "dependencies": {
@@ -47878,7 +47878,7 @@
                 "npmlog": "^6.0.0",
                 "rimraf": "^3.0.2",
                 "semver": "^7.3.5",
-                "tar": "7.5.3",
+                "tar": "7.5.4",
                 "which": "^2.0.2"
             },
             "dependencies": {
@@ -50991,7 +50991,7 @@
                 "node-addon-api": "^7.0.0",
                 "node-gyp": "8.x",
                 "prebuild-install": "^7.1.1",
-                "tar": "7.5.3"
+                "tar": "7.5.4"
             },
             "dependencies": {
                 "node-addon-api": {
@@ -51572,9 +51572,9 @@
             "dev": true
         },
         "tar": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-            "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.4.tgz",
+            "integrity": "sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==",
             "requires": {
                 "@isaacs/fs-minipass": "^4.0.0",
                 "chownr": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2876,6 +2876,6 @@
         "d3-color": "3.1.0",
         "vega-embed": "^7.1.0",
         "@mermaid-js/layout-elk": "npm:empty-pkg@1.0.0",
-        "tar": "7.5.3"
+        "tar@<7.5.4": "7.5.4"
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated tar package version override for proper dependency resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->