### PR TITLE
chore(deps): Add lodash-es override to address vulnerability CVE-2025-13465

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1010,12 +1010,6 @@
                 "lodash-es": "4.17.21"
             }
         },
-        "node_modules/@chevrotain/cst-dts-gen/node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-            "license": "MIT"
-        },
         "node_modules/@chevrotain/gast": {
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
@@ -1025,12 +1019,6 @@
                 "@chevrotain/types": "11.0.3",
                 "lodash-es": "4.17.21"
             }
-        },
-        "node_modules/@chevrotain/gast/node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-            "license": "MIT"
         },
         "node_modules/@chevrotain/regexp-to-ast": {
             "version": "11.0.3",
@@ -5583,12 +5571,6 @@
                 "react": "^16.14.0 || >=17"
             }
         },
-        "node_modules/@jupyterlab/ui-components/node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-            "license": "MIT"
-        },
         "node_modules/@jupyterlab/ui-components/node_modules/react": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -6772,12 +6754,6 @@
             "peerDependencies": {
                 "react": "^16.14.0 || >=17"
             }
-        },
-        "node_modules/@rjsf/utils/node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-            "license": "MIT"
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
@@ -11089,18 +11065,6 @@
                 "chevrotain": "^11.0.0"
             }
         },
-        "node_modules/chevrotain-allstar/node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-            "license": "MIT"
-        },
-        "node_modules/chevrotain/node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-            "license": "MIT"
-        },
         "node_modules/chokidar": {
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -12893,12 +12857,6 @@
                 "d3": "^7.9.0",
                 "lodash-es": "^4.17.21"
             }
-        },
-        "node_modules/dagre-d3-es/node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-            "license": "MIT"
         },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
@@ -21560,9 +21518,10 @@
             "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
         },
         "node_modules/lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+            "license": "MIT"
         },
         "node_modules/lodash.assign": {
             "version": "4.2.0",
@@ -31809,14 +31768,7 @@
             "requires": {
                 "@chevrotain/gast": "11.0.3",
                 "@chevrotain/types": "11.0.3",
-                "lodash-es": "4.17.23"
-            },
-            "dependencies": {
-                "lodash-es": {
-                    "version": "4.17.23",
-                    "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-                    "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
-                }
+                "lodash-es": "^4.17.23"
             }
         },
         "@chevrotain/gast": {
@@ -31825,14 +31777,7 @@
             "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
             "requires": {
                 "@chevrotain/types": "11.0.3",
-                "lodash-es": "4.17.23"
-            },
-            "dependencies": {
-                "lodash-es": {
-                    "version": "4.17.23",
-                    "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-                    "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
-                }
+                "lodash-es": "^4.17.23"
             }
         },
         "@chevrotain/regexp-to-ast": {
@@ -35200,15 +35145,10 @@
                     "integrity": "sha512-ONTr14s7LFIjx2VRFLuOpagL76sM/HPy6/OhdBfq6UukINmTIs6+aFN0GgcR0aXQHFDXQ7f/fel0o/SO05Htdg==",
                     "requires": {
                         "lodash": "^4.17.21",
-                        "lodash-es": "4.17.23",
+                        "lodash-es": "^4.17.23",
                         "markdown-to-jsx": "^7.4.1",
                         "prop-types": "^15.8.1"
                     }
-                },
-                "lodash-es": {
-                    "version": "4.17.23",
-                    "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-                    "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
                 },
                 "react": {
                     "version": "18.3.1",
@@ -36148,15 +36088,8 @@
                 "json-schema-merge-allof": "^0.8.1",
                 "jsonpointer": "^5.0.1",
                 "lodash": "^4.17.21",
-                "lodash-es": "4.17.23",
+                "lodash-es": "^4.17.23",
                 "react-is": "^18.2.0"
-            },
-            "dependencies": {
-                "lodash-es": {
-                    "version": "4.17.23",
-                    "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-                    "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
-                }
             }
         },
         "@sinclair/typebox": {
@@ -39350,14 +39283,7 @@
                 "@chevrotain/regexp-to-ast": "11.0.3",
                 "@chevrotain/types": "11.0.3",
                 "@chevrotain/utils": "11.0.3",
-                "lodash-es": "4.17.23"
-            },
-            "dependencies": {
-                "lodash-es": {
-                    "version": "4.17.23",
-                    "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-                    "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
-                }
+                "lodash-es": "^4.17.23"
             }
         },
         "chevrotain-allstar": {
@@ -39365,14 +39291,7 @@
             "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
             "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
             "requires": {
-                "lodash-es": "4.17.23"
-            },
-            "dependencies": {
-                "lodash-es": {
-                    "version": "4.17.23",
-                    "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-                    "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
-                }
+                "lodash-es": "^4.17.23"
             }
         },
         "chokidar": {
@@ -40693,14 +40612,7 @@
             "integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
             "requires": {
                 "d3": "^7.9.0",
-                "lodash-es": "4.17.23"
-            },
-            "dependencies": {
-                "lodash-es": {
-                    "version": "4.17.23",
-                    "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-                    "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
-                }
+                "lodash-es": "^4.17.23"
             }
         },
         "damerau-levenshtein": {
@@ -46813,9 +46725,9 @@
             "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
         },
         "lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
         },
         "lodash.assign": {
             "version": "4.2.0",
@@ -47233,7 +47145,7 @@
                 "dompurify": "^3.2.5",
                 "katex": "^0.16.22",
                 "khroma": "^2.1.0",
-                "lodash-es": "^4.17.21",
+                "lodash-es": "^4.17.23",
                 "marked": "^16.2.1",
                 "roughjs": "^4.6.6",
                 "stylis": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -2877,6 +2877,6 @@
         "vega-embed": "^7.1.0",
         "@mermaid-js/layout-elk": "npm:empty-pkg@1.0.0",
         "tar@<7.5.4": "7.5.4",
-        "lodash-es@<4.17.23": "4.17.23"
+        "lodash-es": "^4.17.23"
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned dependency lodash‑es to version 4.17.23 in the project manifest.
  * Minor formatting update to the manifest’s overrides section to accommodate the new entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->