### PR TITLE
chore: Upgrade Toolkit to v2.1.1

### DIFF
--- a/src/kernels/deepnote/types.ts
+++ b/src/kernels/deepnote/types.ts
@@ -382,6 +382,6 @@ export interface IDeepnoteLspClientManager {
     stopAllClients(token?: vscode.CancellationToken): Promise<void>;
 }
 
-export const DEEPNOTE_TOOLKIT_VERSION = '1.1.0';
+export const DEEPNOTE_TOOLKIT_VERSION = '2.1.1';
 export const DEEPNOTE_DEFAULT_PORT = 8888;
 export const DEEPNOTE_NOTEBOOK_TYPE = 'deepnote';


### PR DESCRIPTION
The breaking change is the removal of support for Python 3.9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Deepnote Toolkit version to 2.1.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->