### PR TITLE
Enable Deepnote snapshots by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1652,7 +1652,7 @@
                 },
                 "deepnote.snapshots.enabled": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "When enabled, outputs are saved to separate snapshot files in a 'snapshots' folder instead of the main .deepnote file.",
                     "scope": "resource"
                 },

--- a/src/notebooks/deepnote/deepnoteActivationService.ts
+++ b/src/notebooks/deepnote/deepnoteActivationService.ts
@@ -77,7 +77,7 @@ export class DeepnoteActivationService implements IExtensionSyncActivationServic
 
         const config = workspace.getConfiguration('deepnote');
 
-        return config.get<boolean>('snapshots.enabled', false);
+        return config.get<boolean>('snapshots.enabled', true);
     }
 
     private promptReloadForSnapshots(): void {

--- a/src/notebooks/deepnote/snapshots/snapshotService.ts
+++ b/src/notebooks/deepnote/snapshots/snapshotService.ts
@@ -328,7 +328,7 @@ export class SnapshotService implements ISnapshotMetadataService, IExtensionSync
     isSnapshotsEnabled(): boolean {
         const config = workspace.getConfiguration('deepnote');
 
-        return config.get<boolean>('snapshots.enabled', false);
+        return config.get<boolean>('snapshots.enabled', true);
     }
 
     mergeOutputsIntoBlocks(blocks: DeepnoteBlock[], outputs: Map<string, DeepnoteOutput[]>): DeepnoteBlock[] {

--- a/src/notebooks/deepnote/snapshots/snapshotService.unit.test.ts
+++ b/src/notebooks/deepnote/snapshots/snapshotService.unit.test.ts
@@ -438,7 +438,7 @@ suite('SnapshotService', () => {
     suite('isSnapshotsEnabled', () => {
         test('should return true when snapshots.enabled is true', () => {
             const mockConfig = mock<WorkspaceConfiguration>();
-            when(mockConfig.get<boolean>('snapshots.enabled', false)).thenReturn(true);
+            when(mockConfig.get<boolean>('snapshots.enabled', true)).thenReturn(true);
             when(mockedVSCodeNamespaces.workspace.getConfiguration('deepnote')).thenReturn(instance(mockConfig));
 
             const result = service.isSnapshotsEnabled();
@@ -448,7 +448,7 @@ suite('SnapshotService', () => {
 
         test('should return false when snapshots.enabled is false', () => {
             const mockConfig = mock<WorkspaceConfiguration>();
-            when(mockConfig.get<boolean>('snapshots.enabled', false)).thenReturn(false);
+            when(mockConfig.get<boolean>('snapshots.enabled', true)).thenReturn(false);
             when(mockedVSCodeNamespaces.workspace.getConfiguration('deepnote')).thenReturn(instance(mockConfig));
 
             const result = service.isSnapshotsEnabled();
@@ -1007,7 +1007,7 @@ project:
             test('should detect Run All when all code cells are executed', async () => {
                 // Set up mocks
                 const mockConfig = mock<WorkspaceConfiguration>();
-                when(mockConfig.get<boolean>('snapshots.enabled', false)).thenReturn(true);
+                when(mockConfig.get<boolean>('snapshots.enabled', true)).thenReturn(true);
                 when(mockedVSCodeNamespaces.workspace.getConfiguration('deepnote')).thenReturn(instance(mockConfig));
 
                 const projectId = 'test-project-id';


### PR DESCRIPTION
## Summary
Changes the default value of the `deepnote.snapshots.enabled` configuration setting from `false` to `true`, enabling snapshot functionality for Deepnote notebooks by default.

## Changes
- Updated the default value in `package.json` configuration schema from `false` to `true`
- Updated default parameter in `DeepnoteActivationService.isSnapshotsEnabled()` method
- Updated default parameter in `SnapshotService.isSnapshotsEnabled()` method
- Updated unit tests to reflect the new default value in mock configurations

## Details
This change makes snapshot functionality opt-out rather than opt-in, meaning outputs will now be saved to separate snapshot files in a 'snapshots' folder by default instead of being stored in the main .deepnote file. Users who prefer the previous behavior can disable this feature by setting `deepnote.snapshots.enabled` to `false` in their workspace configuration.

All related code paths and tests have been updated to maintain consistency across the codebase.

https://claude.ai/code/session_012kUL7YuMgYq3CR1xqnrLb5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configuration change: Deepnote snapshot outputs are now enabled by default across all notebooks, changing from disabled by default to provide automatic snapshot functionality without requiring users to manually enable the feature.

* **Tests**
  * Updated unit tests to reflect the new default snapshot configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->