### PR TITLE
fix(test): Update CDN test to not rely on HTTP requests failing, but mock them instead

### DIFF
--- a/src/notebooks/controllers/ipywidgets/scriptSourceProvider/cdnWidgetScriptSourceProvider.unit.test.ts
+++ b/src/notebooks/controllers/ipywidgets/scriptSourceProvider/cdnWidgetScriptSourceProvider.unit.test.ts
@@ -4,12 +4,14 @@
 import { assert } from 'chai';
 import fs from 'fs-extra';
 import nock from 'nock';
+import * as sinon from 'sinon';
 import * as path from '../../../../platform/vscode-path/path';
 import { Readable } from 'stream';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { ConfigurationTarget, Disposable, Memento, Uri } from 'vscode';
 import { JupyterSettings } from '../../../../platform/common/configSettings';
 import { ConfigurationService } from '../../../../platform/common/configuration/service.node';
+import { HttpClient } from '../../../../platform/common/net/httpClient';
 import { IConfigurationService, IDisposable, WidgetCDNs } from '../../../../platform/common/types';
 import { noop } from '../../../../platform/common/utils/misc';
 import { EXTENSION_ROOT_DIR } from '../../../../platform/constants.node';
@@ -292,6 +294,8 @@ suite('ipywidget - CDN', () => {
     });
     test('When CDN is turned on and widget script is not found, then display a warning about script not found on CDN', async () => {
         settings.widgetScriptSources = ['jsdelivr.com', 'unpkg.com'];
+        const httpExistsStub = sinon.stub(HttpClient.prototype, 'exists').resolves(false);
+        disposables.push(new Disposable(() => httpExistsStub.restore()));
 
         let values = await scriptSourceProvider.getWidgetScriptSource('module1', '1');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup for CDN script source provider tests by improving mock and stub configuration to better simulate runtime conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnote/vscode-deepnote/pull/397)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->