### PR TITLE
chore(deps): Resolve tmp path traversal vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
                 "svg-to-pdfkit": "^0.1.8",
                 "tailwind-merge": "^3.3.1",
                 "tcp-port-used": "^1.0.1",
-                "tmp": "^0.2.4",
+                "tmp": "^0.2.6",
                 "url-parse": "^1.5.10",
                 "uuid": "^13.0.2",
                 "vega": "^6.2.0",
@@ -28632,9 +28632,10 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+            "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=14.14"
             }
@@ -51801,9 +51802,9 @@
             "dev": true
         },
         "tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+            "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="
         },
         "tmpl": {
             "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -2749,7 +2749,7 @@
         "svg-to-pdfkit": "^0.1.8",
         "tailwind-merge": "^3.3.1",
         "tcp-port-used": "^1.0.1",
-        "tmp": "^0.2.4",
+        "tmp": "^0.2.6",
         "url-parse": "^1.5.10",
         "uuid": "^13.0.2",
         "vega": "^6.2.0",


### PR DESCRIPTION
## Summary
- Bump `tmp` from `^0.2.4` (resolved `0.2.5`) to `^0.2.6` to fix [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) — path traversal via unsanitized prefix/postfix (high severity).
- Patch-level upstream change: only adds relative-value validation in the prefix/postfix path. API surface is unchanged, so existing in-repo usages (`tmp.file`, `tmp.dir`, `tmp.tmpdir`, `tmp.tmpNameSync`, `tmp.FileOptions`) keep working.
- The three other audit findings (`elliptic`, `@tootallnate/once`, `uuid`) are already documented and accepted in `.nsprc` — no changes needed there.

## Test plan
- [x] `npx better-npm-audit audit` exits 0 with "All good!"
- [x] `npx tsc --noEmit -p ./tsconfig.json` passes
- [x] `npm run format-fix` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to the latest stable versions for improved reliability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnote/vscode-deepnote/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->