### PR TITLE
feat: add prettier-plugin-tailwindcss for Tailwind CSS class sorting

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -4,6 +4,8 @@ module.exports = {
     tabWidth: 4,
     endOfLine: 'auto',
     trailingComma: 'none',
+    plugins: ['prettier-plugin-tailwindcss'],
+    tailwindStylesheet: './src/webviews/webview-side/dataframe-renderer/tailwind.css',
     overrides: [
         {
             files: ['*.yml', '*.yaml'],

--- a/package.json
+++ b/package.json
@@ -2904,6 +2904,7 @@
         "nyc": "^15.1.0",
         "postcss": "^8.5.14",
         "prettier": "^3.0.0",
+        "prettier-plugin-tailwindcss": "^0.8.0",
         "relative": "^3.0.2",
         "rimraf": "^5.0.1",
         "screenshot-desktop": "^1.15.2",


### PR DESCRIPTION
## Summary

The project uses Tailwind CSS (tailwindcss v4, tailwind-merge) in `DataframeRenderer` and other webviews. Using `prettier-plugin-tailwindcss` enforces the canonical Tailwind class ordering automatically during Prettier formatting runs, improving readability and diff clarity.

## Changes

- `.prettierrc.cjs`: add `prettier-plugin-tailwindcss` to plugins; set `tailwindStylesheet` to point at the existing entry point (`src/webviews/webview-side/dataframe-renderer/tailwind.css`)
- `package.json`: add `prettier-plugin-tailwindcss@^0.8.0` to devDependencies

## References

- npm: https://www.npmjs.com/package/prettier-plugin-tailwindcss
- Tailwind CSS v4 support confirmed; stylesheet path required for v4

---
> Status: Draft — awaiting CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved formatting support for project files, including better Tailwind-aware formatting.
  * Updated development tooling to keep class ordering and stylesheet handling consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->