### PR TITLE
test(e2e): fix the project-rename flake at its root and run the suite once

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,19 +86,9 @@ jobs:
             pip-${{ runner.os }}-py312-
 
       - name: Run E2E
-        # ExTester launches VS Code with --no-sandbox by default, so no AppArmor sysctl is needed.
-        # A small retry absorbs transient UI/launch flakiness (mocha already retries the test once).
-        run: |
-          attempt=1
-          max=2
-          until xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run test:e2e:prebuilt; do
-            if [ "$attempt" -ge "$max" ]; then
-              echo "E2E failed after $attempt attempt(s)"
-              exit 1
-            fi
-            echo "E2E attempt $attempt failed — retrying…"
-            attempt=$((attempt + 1))
-          done
+        # VS Code launches with --no-sandbox (no AppArmor sysctl needed). Runs once; Mocha's retries:1
+        # and rootHooks.ts (dismiss toasts between tests) handle flakiness in the single shared instance.
+        run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run test:e2e:prebuilt
 
       - name: Upload failure screenshots
         if: failure()

--- a/test/e2e/.mocharc.js
+++ b/test/e2e/.mocharc.js
@@ -1,9 +1,14 @@
 // Mocha configuration for the ExTester (vscode-extension-tester) E2E suite.
 // UI tests are slow: the 2s Mocha default is unusable. Individual waits inside the
 // tests are the real guard rails; this is a generous suite-level safety net.
+const path = require('path');
+
 module.exports = {
     timeout: 1500000, // 25 min — env creation + first kernel start (venv + toolkit) can be slow
     retries: 1, // absorb transient UI flakiness with a single retry
     reporter: 'spec',
-    color: true
+    color: true,
+    // Dismiss notification toasts between tests (rootHooks) so they don't accumulate across the one
+    // shared VS Code instance. Points at compiled output, so compile-e2e must run first.
+    require: [path.resolve(__dirname, '..', '..', 'out', 'e2e', 'rootHooks.js')]
 };

--- a/test/e2e/rootHooks.ts
+++ b/test/e2e/rootHooks.ts
@@ -1,0 +1,9 @@
+import { dismissAllNotifications } from './helpers/notifications';
+
+// Mocha root hooks (wired via .mocharc.js `require`). ExTester runs every spec in ONE shared VS Code
+// instance; dismiss notification toasts between tests so they don't pile up and slow/overlap later specs.
+export const mochaHooks = {
+    async afterEach(): Promise<void> {
+        await dismissAllNotifications().catch(() => undefined);
+    }
+};

--- a/test/e2e/suite/projectRename.e2e.test.ts
+++ b/test/e2e/suite/projectRename.e2e.test.ts
@@ -40,14 +40,27 @@ async function leaveUnsavedCellEdit(): Promise<void> {
 
     await openWorkspaceFile(DIRTIED_FILE);
 
-    // Focus the first CODE cell's Monaco editor by clicking its visible source line (markdown cells
-    // render without an editor, so scope to code rows), then type a marker into the focused input.
-    const line = await driver.wait(
-        async () => (await driver.findElements(By.css('.notebookOverlay .code-cell-row .view-line')))[0],
+    // Click the first CODE cell's source line to focus its editor (markdown cells have none); locate
+    // and click in one retried step, since the cell re-renders on open and can stale a prior reference.
+    await driver.wait(
+        async () => {
+            const line = (await driver.findElements(By.css('.notebookOverlay .code-cell-row .view-line')))[0];
+
+            if (!line) {
+                return false;
+            }
+
+            try {
+                await line.click();
+
+                return true;
+            } catch {
+                return false;
+            }
+        },
         WORKBENCH_TIMEOUT,
-        'the notebook code cell did not render'
+        'the notebook code cell did not render or settle enough to focus'
     );
-    await line.click();
     await driver.sleep(400);
     await driver.switchTo().activeElement().sendKeys(DIRTY_MARKER);
 


### PR DESCRIPTION
## Summary

Fixes the flaky `projectRename` E2E suite at its root and drops the expensive whole-suite retry. Surgical — 4 files.

- **Runs once in CI.** Removes the `until … max=2` shell loop in `e2e.yml` that reran all 16 spec files on any failure.
- **Fixes the actual flake.** `projectRename` failed reproducibly deep in the shared run but passed in a fresh instance. `leaveUnsavedCellEdit` located the first code cell's `.view-line` then `.click()`d it as a *separate* step; the notebook re-renders its cells on open, staling that reference before the click lands (`StaleElementReferenceError`) — far likelier when the shared instance is sluggish late in the run. It now locates **and** clicks in one retried `driver.wait` step (the fix from #375).
- **Isolation.** ExTester runs every spec in one shared VS Code instance, and no suite dismissed notification toasts in teardown, so they stacked up — `waitForNotification` polls every visible toast each tick, slowing later specs and overlapping the tree/menus/inputs they drive. A Mocha root `afterEach` (`test/e2e/rootHooks.ts`, wired via `.mocharc.js`) now dismisses them between tests.

## Validation

Ran the full stack locally exactly as CI does — packaged the VSIX, downloaded test VS Code 1.111.0 + ChromeDriver, installed the built extension + the Python extension, under Xvfb:

- **Full suite, single run: 54 passing, 0 failing, 1 pending** (the intentional `it.skip`). `projectRename` passes **in-place** — it failed 2/2 full runs before this fix.
- `npm run compile-e2e` clean; `npm run format-fix` clean.

## Known follow-up (not in this PR)

Running kernels/servers and global environments created by the cell-running suites are not torn down between suites. The run is green despite this now that the race is fixed, but fully isolating them means per-suite environment teardown, which re-provisions venvs and adds CI time — a separate cost/isolation decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELgnvYGB68gTtHncpWN588


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when editing unsaved notebook cells during project renaming.
  * Prevented notification messages from lingering between end-to-end test scenarios.

* **Tests**
  * Streamlined end-to-end test execution and improved handling of transient interface updates.
  * Enhanced test setup to consistently reset notifications and use compiled test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->