### PR TITLE
fix(lint): clean up oxlint migration follow-ups

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,7 +37,7 @@
             "fileLocation": "relative",
             "pattern": [
                 {
-                    "regexp": "^\\s*(.*):(\\d+):(\\d+):\\s+(error|warning)\\s+(.*)$",
+                    "regexp": "^\\s*(.*):(\\d+):(\\d+):\\s+(error|warning):?\\s+(.*)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,
@@ -117,11 +117,14 @@
             }
         },
         {
-            "type": "npm",
-            "script": "lint",
+            // Not `"type": "npm"` running the `lint` script: that omits `--format`, so oxlint
+            // emits its graphical report, which the `$oxlint` matcher can't parse. The script
+            // stays format-free so CI keeps oxlint's automatic GitHub-annotation output.
+            "type": "shell",
+            "command": "npx oxlint --format=agent src",
             "problemMatcher": "$oxlint",
-            "label": "npm: lint",
-            "detail": "oxlint src",
+            "label": "Lint",
+            "detail": "oxlint --format=agent src",
             "group": {
                 "kind": "build"
             }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,6 +28,23 @@
                 "beginsPattern": "^\\[watch\\] build started",
                 "endsPattern": "^\\[watch\\] build (finished|failed)"
             }
+        },
+        {
+            "name": "oxlint",
+            "label": "oxlint",
+            "owner": "oxlint",
+            "source": "oxlint",
+            "fileLocation": "relative",
+            "pattern": [
+                {
+                    "regexp": "^\\s*(.*):(\\d+):(\\d+):\\s+(error|warning)\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
         }
     ],
     "tasks": [
@@ -102,7 +119,7 @@
         {
             "type": "npm",
             "script": "lint",
-            "problemMatcher": [],
+            "problemMatcher": "$oxlint",
             "label": "npm: lint",
             "detail": "oxlint src",
             "group": {

--- a/build/eslint-rules/index.js
+++ b/build/eslint-rules/index.js
@@ -1,11 +1,9 @@
-const { isBuiltin } = require('node:module');
-
 // Force everything to use the custom vscode-path instead. General Node-builtin detection is
 // handled by oxlint's native `import/no-nodejs-modules` rule (see oxlint.config.mts); this rule
 // only still covers `path`, since that ban applies unconditionally, including in .node.ts files,
 // which no-nodejs-modules can't express (it's turned off there for legitimate Node builtins).
 function reportIfPath(context, node, name) {
-    if (isBuiltin(name) && name === 'path') {
+    if (name === 'path' || name === 'node:path') {
         context.report({ node, message: `Do not import path builtin module. Use the custom vscode-path instead.` });
     }
 }

--- a/build/eslint-rules/index.js
+++ b/build/eslint-rules/index.js
@@ -1,20 +1,10 @@
 const { isBuiltin } = require('node:module');
-const path = require('path');
 
-const testFolder = path.join('src', 'test');
-
-function reportIfMissing(context, node, allowed, name) {
-    const fileName = context.filename;
-    if (
-        allowed.indexOf(name) === -1 &&
-        isBuiltin(name) &&
-        !fileName.endsWith('.node.ts') &&
-        !fileName.endsWith('.test.ts') &&
-        !fileName.includes(testFolder)
-    ) {
-        context.report({ node, message: `Do not import Node.js builtin module "${name}"` });
-    }
-    // Special case 'path'. Force everything to use the custom path
+// Force everything to use the custom vscode-path instead. General Node-builtin detection is
+// handled by oxlint's native `import/no-nodejs-modules` rule (see oxlint.config.mts); this rule
+// only still covers `path`, since that ban applies unconditionally, including in .node.ts files,
+// which no-nodejs-modules can't express (it's turned off there for legitimate Node builtins).
+function reportIfPath(context, node, name) {
     if (isBuiltin(name) && name === 'path') {
         context.report({ node, message: `Do not import path builtin module. Use the custom vscode-path instead.` });
     }
@@ -26,33 +16,15 @@ module.exports = {
             meta: {
                 type: 'problem',
                 docs: {
-                    description: 'Check for node.js builtins in non-node files',
+                    description: 'Force use of the custom vscode-path module instead of the builtin `path`',
                     category: 'import'
-                },
-                schema: [
-                    {
-                        type: 'object',
-                        properties: {
-                            allow: {
-                                type: 'array',
-                                uniqueItems: true,
-                                items: {
-                                    type: 'string'
-                                }
-                            }
-                        },
-                        additionalProperties: false
-                    }
-                ]
+                }
             },
             create: function (context) {
-                const options = context.options[0] || {};
-                const allowed = options.allow || [];
-
                 // `export { x }` and `export const x = 1` carry no source to check.
                 function checkSource(node) {
                     if (node.source) {
-                        reportIfMissing(context, node, allowed, node.source.value);
+                        reportIfPath(context, node, node.source.value);
                     }
                 }
 
@@ -62,7 +34,7 @@ module.exports = {
                     ExportAllDeclaration: checkSource,
                     ImportExpression(node) {
                         if (node.source.type === 'Literal' && typeof node.source.value === 'string') {
-                            reportIfMissing(context, node, allowed, node.source.value);
+                            reportIfPath(context, node, node.source.value);
                         }
                     },
                     CallExpression(node) {
@@ -73,7 +45,7 @@ module.exports = {
                             node.arguments[0].type === 'Literal' &&
                             typeof node.arguments[0].value === 'string'
                         ) {
-                            reportIfMissing(context, node, allowed, node.arguments[0].value);
+                            reportIfPath(context, node, node.arguments[0].value);
                         }
                     }
                 };

--- a/oxlint.config.mts
+++ b/oxlint.config.mts
@@ -49,14 +49,15 @@ const restrictedPathZones: Rules['import-plugin/no-restricted-paths'] = [
             },
             {
                 target: './src/kernels/**/*[!.unit].ts',
-                from: './src/**[!platform,telemetry,kernels]**/**/*.ts',
-                message: 'Only modules from ./src/platform and ./src/telemetry can be imported into ./src/kernels.'
+                from: './src/**[!platform,telemetry,kernels,codespaces]**/**/*.ts',
+                message:
+                    'Only modules from ./src/platform, ./src/telemetry and ./src/codespaces can be imported into ./src/kernels.'
             },
             {
                 target: './src/notebooks/**/*[!.unit].ts',
-                from: './src/**[!platform,telemetry,kernels,notebooks]**/**/*.ts',
+                from: './src/**[!platform,telemetry,kernels,notebooks,codespaces]**/**/*.ts',
                 message:
-                    'Only modules from ./src/platform, ./src/telemetry and ./src/kernels can be imported into ./src/notebooks.'
+                    'Only modules from ./src/platform, ./src/telemetry, ./src/kernels and ./src/codespaces can be imported into ./src/notebooks.'
             },
             {
                 target: './src/interactive-window/**/*[!.unit].ts',
@@ -123,14 +124,17 @@ const baseRules: Rules = {
         }
     ],
     'import-plugin/no-restricted-paths': restrictedPathZones,
-    'local-rules/node-imports': ['error', { allow: ['events'] }],
+    // Node-builtin detection now runs through oxlint's native rule (see overrides below for
+    // the .node.ts/.test.ts exceptions); the custom rule only still handles the `path` ban.
+    'import/no-nodejs-modules': ['error', { allow: ['events'] }],
+    'local-rules/node-imports': 'error',
     'local-rules/dont-use-process': ['error'],
     'local-rules/dont-use-fspath': ['error'],
     'local-rules/dont-use-filename': ['error']
 };
 
 export default defineConfig({
-    plugins: ['eslint', 'typescript', 'react'],
+    plugins: ['eslint', 'typescript', 'react', 'import'],
     // Only rules listed below run. Without pinning every category off, naming a plugin
     // pulls in its whole `correctness` set — far wider than the 21 rules ESLint enforced.
     categories: {
@@ -179,8 +183,13 @@ export default defineConfig({
             rules: {
                 'typescript/no-explicit-any': 'off',
                 'no-restricted-imports': 'off',
-                'no-empty-function': 'off'
+                'no-empty-function': 'off',
+                'import/no-nodejs-modules': 'off'
             }
+        },
+        {
+            files: ['**/*.node.ts'],
+            rules: { 'import/no-nodejs-modules': 'off' }
         },
         {
             files: ['src/*.d.ts'],

--- a/src/kernels/execution/cellExecutionQueue.ts
+++ b/src/kernels/execution/cellExecutionQueue.ts
@@ -14,7 +14,6 @@ import { CodeExecution } from './codeExecution';
 import { once } from '../../platform/common/utils/events';
 import { getCellMetadata } from '../../platform/common/utils';
 import { NotebookCellExecutionState, notebookCellExecutions } from '../../platform/notebooks/cellExecutionStateService';
-// eslint-disable-next-line import/no-restricted-paths
 import { ISnapshotMetadataService } from '../../notebooks/deepnote/snapshots/snapshotService'; // oxlint-disable-line import-plugin/no-restricted-paths
 
 /**

--- a/src/kernels/jupyter/serviceRegistry.node.ts
+++ b/src/kernels/jupyter/serviceRegistry.node.ts
@@ -25,8 +25,7 @@ import { JupyterServerProvider } from './launcher/jupyterServerProvider.node';
 import { JupyterServerStarter } from './launcher/jupyterServerStarter.node';
 import { JupyterServerUriStorage } from './connection/serverUriStorage';
 import { LiveRemoteKernelConnectionUsageTracker } from './connection/liveRemoteKernelConnectionTracker';
-// eslint-disable-next-line import/no-restricted-paths
-import { CodespacesJupyterServerSelector } from '../../codespaces/codeSpacesServerSelector'; // oxlint-disable-line import-plugin/no-restricted-paths
+import { CodespacesJupyterServerSelector } from '../../codespaces/codeSpacesServerSelector';
 import { JupyterRequestCreator } from './session/jupyterRequestCreator.node';
 import { RequestAgentCreator } from './session/requestAgentCreator.node';
 import {
@@ -49,8 +48,7 @@ import { RemoteKernelFinderController } from './finder/remoteKernelFinderControl
 import { KernelSessionFactory } from '../common/kernelSessionFactory';
 import { JupyterKernelSessionFactory } from './session/jupyterKernelSessionFactory';
 import { IRemoteKernelFinderController } from './finder/types';
-// eslint-disable-next-line import/no-restricted-paths
-import { JupyterServerProviderRegistry } from '../../codespaces'; // oxlint-disable-line import-plugin/no-restricted-paths
+import { JupyterServerProviderRegistry } from '../../codespaces';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
     serviceManager.add<IJupyterCommandFactory>(IJupyterCommandFactory, JupyterCommandFactory);

--- a/src/kernels/jupyter/serviceRegistry.web.ts
+++ b/src/kernels/jupyter/serviceRegistry.web.ts
@@ -26,10 +26,8 @@ import { RemoteKernelFinderController } from './finder/remoteKernelFinderControl
 import { KernelSessionFactory } from '../common/kernelSessionFactory';
 import { JupyterKernelSessionFactory } from './session/jupyterKernelSessionFactory';
 import { IRemoteKernelFinderController } from './finder/types';
-// eslint-disable-next-line import/no-restricted-paths
-import { JupyterServerProviderRegistry } from '../../codespaces'; // oxlint-disable-line import-plugin/no-restricted-paths
-// eslint-disable-next-line import/no-restricted-paths
-import { CodespacesJupyterServerSelector } from '../../codespaces/codeSpacesServerSelector'; // oxlint-disable-line import-plugin/no-restricted-paths
+import { JupyterServerProviderRegistry } from '../../codespaces';
+import { CodespacesJupyterServerSelector } from '../../codespaces/codeSpacesServerSelector';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
     serviceManager.addSingleton<CodespacesJupyterServerSelector>(

--- a/src/kernels/kernelProvider.node.ts
+++ b/src/kernels/kernelProvider.node.ts
@@ -32,9 +32,7 @@ import { IReplNotebookTrackerService } from '../platform/notebooks/replNotebookT
 import { logger } from '../platform/logging';
 import { getDisplayPath } from '../platform/common/platform/fs-paths.node';
 import { IRawNotebookSupportedService } from './raw/types';
-// eslint-disable-next-line import/no-restricted-paths
 import { ISnapshotMetadataService } from '../notebooks/deepnote/snapshots/snapshotService'; // oxlint-disable-line import-plugin/no-restricted-paths
-// eslint-disable-next-line import/no-restricted-paths
 import { IFederatedAuthSqlBlockCodeGenerator } from '../notebooks/deepnote/integrations/types'; // oxlint-disable-line import-plugin/no-restricted-paths
 
 /**

--- a/src/notebooks/controllers/kernelSource/remoteNotebookKernelSourceSelector.ts
+++ b/src/notebooks/controllers/kernelSource/remoteNotebookKernelSourceSelector.ts
@@ -15,8 +15,7 @@ import {
     notebooks
 } from 'vscode';
 import { IContributedKernelFinder } from '../../../kernels/internalTypes';
-// eslint-disable-next-line import/no-restricted-paths
-import { CodespacesJupyterServerSelector } from '../../../codespaces/codeSpacesServerSelector'; // oxlint-disable-line import-plugin/no-restricted-paths
+import { CodespacesJupyterServerSelector } from '../../../codespaces/codeSpacesServerSelector';
 import {
     IJupyterServerUriStorage,
     IRemoteKernelFinder,

--- a/src/platform/common/crypto.ts
+++ b/src/platform/common/crypto.ts
@@ -31,7 +31,7 @@ async function initCryptoProvider(): Promise<Crypto> {
     }
     // Node
     else {
-        // eslint-disable-next-line local-rules/node-imports
+        // eslint-disable-next-line import/no-nodejs-modules
         const nodeCrypto = await import('node:crypto');
         return nodeCrypto.webcrypto as Crypto;
     }

--- a/src/renderers/client/tsconfig.json
+++ b/src/renderers/client/tsconfig.json
@@ -12,6 +12,7 @@
         "forceConsistentCasingInFileNames": true,
         "outDir": "../../../dist/renderers/client",
         "rootDir": "..",
+        "noEmit": true,
         "typeRoots": ["./types", "../../../node_modules/@types"]
     },
     "include": ["./**/*.ts", "./**/*.tsx"],


### PR DESCRIPTION
## Summary

Follow-up fixes from a code review of #468 (oxlint migration):

- Drop dangling `eslint-disable-next-line import/no-restricted-paths` comments left over at every site where an `oxlint-disable-line` comment was already added — they were harmless today but would start failing the build under `--report-unused-disable-directives`.
- Encode the `codespaces` import exception directly in the `no-restricted-paths` zones (`oxlint.config.mts`) instead of suppressing it at each of the 5 call sites individually.
- Replace the hand-rolled Node-builtin-import detection in `local-rules/node-imports` with oxlint's native `import/no-nodejs-modules` (same `{ allow: [...] }` option shape), with per-file overrides for `.node.ts`/`.test.ts`/`src/test/**` mirroring the old behavior. The custom rule now only keeps the unconditional `path`-import ban, which `no-nodejs-modules` can't express (it needs to still fire inside `.node.ts` files).
- Harden `src/renderers/client/tsconfig.json` with `noEmit: true`. Its `rootDir` was deliberately widened in the migration (to admit a sibling-directory import, per that commit's message) but `outDir`/`include` weren't adjusted to match; the file is IDE-only today (esbuild bundles the actual output, and `typecheck` only runs `tsc -p ./ --noEmit` on the root config), so this just makes that permanent rather than reverting the original fix.

Not changed: `lint-fix`'s narrowed `oxlint --fix src` scope (dropping `build/`/`gulpfile.js`) turned out to be a non-issue — both are already globally excluded via `ignorePatterns` in `oxlint.config.mts`, so passing them to `--fix` would be a no-op.

## Test plan

- [x] `npx oxlint src` — output diffed against the pre-fix baseline; identical (same 27 pre-existing warnings, 0 errors)
- [x] `npm run typecheck` — clean
- [x] `npm run compile-tsc && npm run test:unittests` — 2762 passing, 234 pending, 0 failing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved linting integration and diagnostics in development tasks.
  * Refined Node.js module import checks and exceptions for supported environments.
  * Updated import restrictions for Codespaces-related functionality.
  * Added a configuration to prevent unnecessary TypeScript output during client checks.
  * Cleaned up obsolete lint suppression comments without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->