### PR TITLE
chore: update version to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-deepnote",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-deepnote",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-deepnote",
     "displayName": "Deepnote",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "description": "Deepnote notebook support.",
     "publisher": "Deepnote",
     "author": {


### PR DESCRIPTION
Bumps the extension version from 1.6.0 to 1.7.0 ahead of the v1.7.0 release.

[Changes since v1.6.0](https://github.com/deepnote/vscode-deepnote/compare/v1.6.0...main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyZCw9GzL6Vq7S9MAVYwby

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the extension to version 1.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->