### PR TITLE
fix(ci): clear main audit failures and cd.yml shellcheck findings

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
         id: package-version
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extension version: $VERSION"
 
       - name: Extract and sanitize branch name
@@ -71,7 +71,7 @@ jobs:
           # The package script creates vscode-deepnote-insiders.vsix
           # Rename it to include version and branch
           mv vscode-deepnote-insiders.vsix "vscode-deepnote-${{ steps.package-version.outputs.version }}-${{ steps.branch-name.outputs.branch }}.vsix"
-          ls -lh *.vsix
+          ls -lh ./*.vsix
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -83,21 +83,23 @@ jobs:
 
       - name: Add summary
         run: |
-          echo "## 📦 Extension Packaged Successfully" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.package-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** ${{ steps.branch-name.outputs.branch }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Installation Instructions" >> $GITHUB_STEP_SUMMARY
-          echo "1. Download the artifact from the Actions tab" >> $GITHUB_STEP_SUMMARY
-          echo "2. Extract the .vsix file from the zip" >> $GITHUB_STEP_SUMMARY
-          echo "3. Install in VS Code:" >> $GITHUB_STEP_SUMMARY
-          echo "   - Open VS Code" >> $GITHUB_STEP_SUMMARY
-          echo "   - Go to Extensions view (Ctrl+Shift+X / Cmd+Shift+X)" >> $GITHUB_STEP_SUMMARY
-          echo "   - Click the '...' menu → 'Install from VSIX...'" >> $GITHUB_STEP_SUMMARY
-          echo "   - Select the downloaded .vsix file" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Alternatively, use the command line:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "code --install-extension vscode-deepnote-${{ steps.package-version.outputs.version }}-${{ steps.branch-name.outputs.branch }}.vsix" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## 📦 Extension Packaged Successfully
+
+          **Version:** ${{ steps.package-version.outputs.version }}
+          **Branch:** ${{ steps.branch-name.outputs.branch }}
+
+          ### Installation Instructions
+          1. Download the artifact from the Actions tab
+          2. Extract the .vsix file from the zip
+          3. Install in VS Code:
+             - Open VS Code
+             - Go to Extensions view (Ctrl+Shift+X / Cmd+Shift+X)
+             - Click the '...' menu → 'Install from VSIX...'
+             - Select the downloaded .vsix file
+
+          Alternatively, use the command line:
+          ```bash
+          code --install-extension vscode-deepnote-${{ steps.package-version.outputs.version }}-${{ steps.branch-name.outputs.branch }}.vsix
+          ```
+          EOF

--- a/package-lock.json
+++ b/package-lock.json
@@ -3341,9 +3341,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -22120,9 +22120,9 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "funding": [
                 {
                     "type": "github",
@@ -24651,10 +24651,11 @@
             }
         },
         "node_modules/morgan": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
-            "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.12.0.tgz",
+            "integrity": "sha512-OHpTRQwn2ezasILW8iKe+Yww1XsfWsZIpUOLF7RDb2g5GwO3trPaRwi7+8BDiJ7HFx2Kg2mfUdCBcVhwYlOz2g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "basic-auth": "~2.0.1",
                 "debug": "2.6.9",
@@ -30044,9 +30045,9 @@
             }
         },
         "node_modules/smol-toml": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+            "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -36621,7 +36622,7 @@
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
                 "get-package-type": "^0.1.0",
-                "js-yaml": "3.15.1",
+                "js-yaml": "3.15.2",
                 "resolve-from": "^5.0.0"
             },
             "dependencies": {
@@ -36643,9 +36644,9 @@
                     }
                 },
                 "js-yaml": {
-                    "version": "3.15.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-                    "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+                    "version": "3.15.2",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+                    "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
                     "requires": {
                         "argparse": "^1.0.7",
                         "esprima": "^4.0.0"
@@ -44496,7 +44497,7 @@
             "requires": {
                 "@cspell/cspell-types": "9.8.0",
                 "comment-json": "^4.6.2",
-                "smol-toml": "1.6.1",
+                "smol-toml": "1.8.0",
                 "yaml": "2.8.3"
             }
         },
@@ -50041,9 +50042,9 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "requires": {
                 "argparse": "^2.0.1"
             }
@@ -50459,7 +50460,7 @@
             "integrity": "sha512-JOUdCNlc21G50afBXfErUrr1RKymbgzlrO5KURY+wmDG1Uvd2jmxUJcHgylb/mYXy2SjiNZyYim/ptUBGsIi3A==",
             "dev": true,
             "requires": {
-                "morgan": "^1.6.1"
+                "morgan": "1.12.0"
             }
         },
         "koa-mount": {
@@ -51787,9 +51788,9 @@
             }
         },
         "morgan": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
-            "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.12.0.tgz",
+            "integrity": "sha512-OHpTRQwn2ezasILW8iKe+Yww1XsfWsZIpUOLF7RDb2g5GwO3trPaRwi7+8BDiJ7HFx2Kg2mfUdCBcVhwYlOz2g==",
             "dev": true,
             "requires": {
                 "basic-auth": "~2.0.1",
@@ -55538,9 +55539,9 @@
             "optional": true
         },
         "smol-toml": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+            "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
             "dev": true
         },
         "socks": {

--- a/package.json
+++ b/package.json
@@ -2995,7 +2995,7 @@
         "sinon": {
             "diff": "5.2.2"
         },
-        "smol-toml": "1.6.1",
+        "smol-toml": "1.8.0",
         "tslint": {
             "diff": "4.0.4"
         },
@@ -3022,7 +3022,8 @@
         "form-data@>=4.0.0 <4.0.6": "4.0.6",
         "body-parser": "2.3.0",
         "immutable": "4.3.9",
-        "js-yaml@3": "3.15.1",
+        "js-yaml@3": "3.15.2",
+        "morgan@<1.12.0": "1.12.0",
         "@tootallnate/once": "2.0.1",
         "uuid@8": "11.1.1"
     }


### PR DESCRIPTION
All three blocking CI jobs are failing on `main` ([run](https://github.com/deepnote/vscode-deepnote/actions/runs/34465746883)): `Audit - Production`, `Audit - All` and `Qlty Check`. This is independent of #497 (the perf-fixture lockfile), which touches `ci.yml`; this PR touches `cd.yml` and the root dependency tree, so they don't conflict.

## Audit - Production and Audit - All

| Advisory | Package | Severity | Path | Fix |
| --- | --- | --- | --- | --- |
| GHSA-2883-xcg3-v3hh | js-yaml 4.3.1 | high | top-level (direct dep) | `npm update js-yaml` → 4.3.2 |
| GHSA-2883-xcg3-v3hh | js-yaml 3.15.1 | high | `@istanbuljs/load-nyc-config > js-yaml` | override `js-yaml@3` 3.15.1 → 3.15.2 |
| GHSA-jxfw-x594-9x9m | morgan 1.11.0 | moderate | `koa-morgan > morgan` (dev only) | new override `morgan@<1.12.0: 1.12.0` |
| GHSA-7w5x-hrqm-74c2 | smol-toml 1.6.1 | high | override-pinned | override 1.6.1 → 1.8.0 |

The js-yaml finding is what fails `Audit - Production`; the other two only appear in `Audit - All`.

## Qlty Check

21 actionlint/shellcheck findings in `.github/workflows/cd.yml`, all pre-existing but only visible since #481 made qlty analyze files:

- **SC2086** (19×): unquoted `$GITHUB_OUTPUT` / `$GITHUB_STEP_SUMMARY`.
- **SC2035**: bare `*.vsix` glob in `ls`.
- **SC2129**: 18 individual `>> $GITHUB_STEP_SUMMARY` redirects.

Fixed by quoting the env-file paths, using `./*.vsix`, and replacing the echo chain with a single quoted heredoc. The rendered summary is byte-identical apart from no longer needing `\`` escapes.

## Verification

```
$ npx better-npm-audit audit --production
🤝  All good!
$ npx better-npm-audit audit
🤝  All good!
$ actionlint .github/workflows/cd.yml && qlty check --all --filter=actionlint
✔ No issues
```

## Heads-up, not addressed here

The `.nsprc` exception for elliptic (`GHSA-848j-6mx2-7j84`) expires **2026-09-17**. `npm audit` reports no fix available (it's pulled in via `node-stdlib-browser > crypto-browserify`), so `Audit - All` will go red again next week unless the expiry is extended or the exception re-justified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
