### PR TITLE
feat(explorer): add notebook toolbar button to reveal the Deepnote explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Open the Command Palette (`Cmd+Shift+P` or `Ctrl+Shift+P`) and type `Deepnote` t
 | `Deepnote: Open Notebook`          | Open a specific notebook from a Deepnote project   |
 | `Deepnote: Open File`              | Open the raw .deepnote project file                |
 | `Deepnote: Reveal in Explorer`     | Show active notebook information in the explorer   |
+| `Deepnote: Show Project Explorer`  | Show the Deepnote sidebar and select the notebook  |
 | `Deepnote: Manage Integrations`    | Configure database connections and credentials     |
 | `Deepnote: New Project`            | Create a new Deepnote project                      |
 | `Deepnote: Import Notebook`        | Import an existing notebook into your project      |

--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ Or install from the [VS Code Marketplace](https://marketplace.visualstudio.com/i
 
 Open the Command Palette (`Cmd+Shift+P` or `Ctrl+Shift+P`) and type `Deepnote` to see all available commands:
 
-| Command                            | Description                                        |
-| ---------------------------------- | -------------------------------------------------- |
-| `Deepnote: Refresh Explorer`       | Refresh the Deepnote project explorer              |
-| `Deepnote: Open Notebook`          | Open a specific notebook from a Deepnote project   |
-| `Deepnote: Open File`              | Open the raw .deepnote project file                |
-| `Deepnote: Reveal in Explorer`     | Show active notebook information in the explorer   |
-| `Deepnote: Show Project Explorer`  | Show the Deepnote sidebar and select the notebook  |
-| `Deepnote: Manage Integrations`    | Configure database connections and credentials     |
-| `Deepnote: New Project`            | Create a new Deepnote project                      |
-| `Deepnote: Import Notebook`        | Import an existing notebook into your project      |
-| `Notebook: Select Notebook Kernel` | Select or switch kernels within your notebook      |
-| `Notebook: Change Cell Language`   | Change the language of the cell currently in focus |
-| `Deepnote: Enable Snapshots`       | Enable snapshot mode for the current workspace     |
+| Command                            | Description                                                             |
+| ---------------------------------- | ----------------------------------------------------------------------- |
+| `Deepnote: Refresh Explorer`       | Refresh the Deepnote project explorer                                   |
+| `Deepnote: Open Notebook`          | Open a specific notebook from a Deepnote project                        |
+| `Deepnote: Open File`              | Open the raw .deepnote project file                                     |
+| `Deepnote: Reveal in Explorer`     | Show active notebook information in the explorer                        |
+| `Deepnote: Show Project Explorer`  | Show the Deepnote sidebar and select the active notebook when available |
+| `Deepnote: Manage Integrations`    | Configure database connections and credentials                          |
+| `Deepnote: New Project`            | Create a new Deepnote project                                           |
+| `Deepnote: Import Notebook`        | Import an existing notebook into your project                           |
+| `Notebook: Select Notebook Kernel` | Select or switch kernels within your notebook                           |
+| `Notebook: Change Cell Language`   | Change the language of the cell currently in focus                      |
+| `Deepnote: Enable Snapshots`       | Enable snapshot mode for the current workspace                          |
 
 ### Database integrations
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,12 @@
                 "icon": "$(reveal)"
             },
             {
+                "command": "deepnote.revealExplorer",
+                "title": "%deepnote.commands.revealExplorer.title%",
+                "category": "Deepnote",
+                "icon": "$(list-tree)"
+            },
+            {
                 "command": "deepnote.enableSnapshots",
                 "title": "%deepnote.commands.enableSnapshots.title%",
                 "category": "Deepnote"
@@ -987,6 +993,11 @@
             ],
             "editor/title": [
                 {
+                    "command": "deepnote.revealExplorer",
+                    "group": "navigation@-2",
+                    "when": "notebookType == 'deepnote' && config.notebook.globalToolbar != true"
+                },
+                {
                     "command": "deepnote.restartkernel",
                     "title": "%deepnote.command.deepnote.restartkernel.title%",
                     "group": "navigation@1",
@@ -1017,6 +1028,11 @@
                 }
             ],
             "notebook/toolbar": [
+                {
+                    "command": "deepnote.revealExplorer",
+                    "group": "navigation@-2",
+                    "when": "notebookType == 'deepnote'"
+                },
                 {
                     "command": "deepnote.openInDeepnote",
                     "group": "navigation@-1",

--- a/package.nls.json
+++ b/package.nls.json
@@ -253,6 +253,7 @@
     "deepnote.commands.openNotebook.title": "Open Notebook",
     "deepnote.commands.openFile.title": "Open File",
     "deepnote.commands.revealInExplorer.title": "Reveal in Explorer",
+    "deepnote.commands.revealExplorer.title": "Show Project Explorer",
     "deepnote.commands.enableSnapshots.title": "Enable Snapshots",
     "deepnote.commands.disableSnapshots.title": "Disable Snapshots",
     "deepnote.commands.manageIntegrations.title": "Manage Integrations",

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -73,6 +73,7 @@ Provides the sidebar UI for browsing and opening Deepnote notebooks.
 -   `deepnote.openNotebook`: Open a specific notebook
 -   `deepnote.openFile`: Open the raw .deepnote file
 -   `deepnote.revealInExplorer`: Show active notebook info
+-   `deepnote.revealExplorer`: Show the Deepnote sidebar and select the active notebook (notebook toolbar button)
 
 ### 5. Tree Data Provider (`deepnoteTreeDataProvider.ts`)
 

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -73,7 +73,7 @@ Provides the sidebar UI for browsing and opening Deepnote notebooks.
 -   `deepnote.openNotebook`: Open a specific notebook
 -   `deepnote.openFile`: Open the raw .deepnote file
 -   `deepnote.revealInExplorer`: Show active notebook info
--   `deepnote.revealExplorer`: Show the Deepnote sidebar and select the active notebook (notebook toolbar button)
+-   `deepnote.revealExplorer`: Show the Deepnote sidebar and select the active notebook when available (notebook toolbar button)
 
 ### 5. Tree Data Provider (`deepnoteTreeDataProvider.ts`)
 

--- a/src/notebooks/deepnote/deepnoteExplorerView.ts
+++ b/src/notebooks/deepnote/deepnoteExplorerView.ts
@@ -27,6 +27,11 @@ import { isSnapshotFile } from './snapshots/snapshotFiles';
 
 type CommandOutcome = 'completed' | 'cancelled' | 'failed';
 
+const DEEPNOTE_EXPLORER_VIEW_ID = 'deepnoteExplorer';
+// VS Code auto-registers `<viewId>.focus` for every contributed view; it opens the owning view container even
+// when that container is hidden or collapsed.
+const DEEPNOTE_EXPLORER_FOCUS_COMMAND = `${DEEPNOTE_EXPLORER_VIEW_ID}.focus`;
+
 /**
  * Manages the Deepnote explorer tree view and its commands. Sibling `.deepnote` files are grouped
  * by `project.id`; project-scoped commands span the group, notebook-scoped ones a single leaf/child.
@@ -44,7 +49,7 @@ export class DeepnoteExplorerView {
     ) {}
 
     public activate(): void {
-        this.treeView = window.createTreeView('deepnoteExplorer', {
+        this.treeView = window.createTreeView(DEEPNOTE_EXPLORER_VIEW_ID, {
             treeDataProvider: this.treeDataProvider,
             showCollapseAll: true
         });
@@ -457,6 +462,10 @@ export class DeepnoteExplorerView {
         );
 
         this.extensionContext.subscriptions.push(
+            commands.registerCommand(Commands.RevealDeepnoteExplorer, () => this.revealExplorer())
+        );
+
+        this.extensionContext.subscriptions.push(
             commands.registerCommand(Commands.NewProject, async () => {
                 const outcome = await this.newProject();
                 this.analytics.trackEvent({ eventName: 'create_project', properties: { outcome } });
@@ -766,29 +775,67 @@ export class DeepnoteExplorerView {
             return;
         }
 
-        // Try to reveal the notebook in the explorer
-        try {
-            const treeItem = await this.treeDataProvider.findTreeItem(projectId, notebookId);
+        // Fall back to describing the notebook when it cannot be selected in the tree.
+        const fallbackMessage = `Active notebook: ${notebookMetadata?.deepnoteNotebookName || 'Untitled'} in project ${
+            notebookMetadata?.deepnoteProjectName || 'Untitled'
+        }`;
 
-            if (treeItem) {
-                await this.treeView.reveal(treeItem, { select: true, focus: true, expand: true });
-            } else {
-                // Fall back to showing information if node not found
-                await window.showInformationMessage(
-                    `Active notebook: ${notebookMetadata?.deepnoteNotebookName || 'Untitled'} in project ${
-                        notebookMetadata?.deepnoteProjectName || 'Untitled'
-                    }`
-                );
+        try {
+            if (!(await this.revealNotebookInTree(projectId, notebookId))) {
+                await window.showInformationMessage(fallbackMessage);
             }
         } catch (error) {
-            // Fall back to showing information if reveal fails
             this.logger.error('Failed to reveal notebook in explorer', error);
-            await window.showInformationMessage(
-                `Active notebook: ${notebookMetadata?.deepnoteNotebookName || 'Untitled'} in project ${
-                    notebookMetadata?.deepnoteProjectName || 'Untitled'
-                }`
-            );
+            await window.showInformationMessage(fallbackMessage);
         }
+    }
+
+    /**
+     * Opens the Deepnote view container with the explorer focused, then selects the active Deepnote notebook in the
+     * tree when there is one. Unlike `revealActiveNotebook`, this never surfaces a message: it backs the notebook
+     * toolbar button, so showing the explorer is the outcome that matters and a missed selection is only logged.
+     */
+    private async revealExplorer(): Promise<void> {
+        // Capture the editor before moving focus to the sidebar.
+        const activeEditor = window.activeNotebookEditor;
+
+        try {
+            await commands.executeCommand(DEEPNOTE_EXPLORER_FOCUS_COMMAND);
+        } catch (error) {
+            this.logger.error('Failed to focus the Deepnote explorer view', error);
+        }
+
+        if (!activeEditor || activeEditor.notebook.notebookType !== 'deepnote') {
+            return;
+        }
+
+        const notebookMetadata = activeEditor.notebook.metadata;
+        const projectId = notebookMetadata?.deepnoteProjectId;
+        const notebookId = notebookMetadata?.deepnoteNotebookId;
+
+        if (!projectId || !notebookId) {
+            return;
+        }
+
+        try {
+            await this.revealNotebookInTree(projectId, notebookId);
+        } catch (error) {
+            // The tree may still be loading; the explorer is already visible, so this is not worth a toast.
+            this.logger.warn('Failed to reveal the active notebook after showing the Deepnote explorer', error);
+        }
+    }
+
+    /** Selects the notebook in the tree; returns false when it is not (yet) part of the tree. */
+    private async revealNotebookInTree(projectId: string, notebookId: string): Promise<boolean> {
+        const treeItem = await this.treeDataProvider.findTreeItem(projectId, notebookId);
+
+        if (!treeItem) {
+            return false;
+        }
+
+        await this.treeView.reveal(treeItem, { select: true, focus: true, expand: true });
+
+        return true;
     }
 
     private async newProject(): Promise<CommandOutcome> {

--- a/src/notebooks/deepnote/deepnoteExplorerView.unit.test.ts
+++ b/src/notebooks/deepnote/deepnoteExplorerView.unit.test.ts
@@ -82,10 +82,11 @@ function makeExtensionContext(): IExtensionContext {
     return { subscriptions: [] } as unknown as IExtensionContext;
 }
 
-function makeNotebookDocument(): NotebookDocument {
+function makeNotebookDocument(metadata?: Record<string, unknown>, notebookType = 'deepnote'): NotebookDocument {
     return {
         uri: Uri.parse('file:///test/notebook.deepnote'),
-        notebookType: 'deepnote',
+        notebookType,
+        metadata,
         version: 1,
         isDirty: false,
         isUntitled: false,
@@ -227,6 +228,111 @@ suite('DeepnoteExplorerView', () => {
                 // Expected in test environment
                 assert.isString(error.message, 'revealActiveNotebook method exists');
             }
+        });
+    });
+
+    suite('revealExplorer', () => {
+        const EXPLORER_FOCUS_COMMAND = 'deepnoteExplorer.focus';
+        const notebookMetadata = { deepnoteProjectId: 'project-1', deepnoteNotebookId: 'notebook-1' };
+        const treeItem = { label: 'Quick Notes' } as unknown as DeepnoteTreeItem;
+        let treeDataProvider: DeepnoteTreeDataProvider;
+        let findTreeItem: sinon.SinonStub;
+        let reveal: sinon.SinonStub;
+
+        function stubActiveNotebook(metadata?: Record<string, unknown>, notebookType?: string): void {
+            when(mockedVSCodeNamespaces.window.activeNotebookEditor).thenReturn({
+                notebook: makeNotebookDocument(metadata, notebookType)
+            } as unknown as NotebookEditor);
+        }
+
+        setup(() => {
+            reveal = sinon.stub().resolves();
+            when(mockedVSCodeNamespaces.window.createTreeView(anything(), anything())).thenReturn({
+                reveal,
+                dispose: () => undefined
+            } as never);
+
+            treeDataProvider = new DeepnoteTreeDataProvider(mockLogger);
+            findTreeItem = sinon.stub(treeDataProvider, 'findTreeItem').resolves(treeItem);
+
+            explorerView = new DeepnoteExplorerView(mockExtensionContext, mockLogger, treeDataProvider, mockAnalytics);
+            explorerView.activate();
+        });
+
+        teardown(() => {
+            sinon.restore();
+        });
+
+        test('focuses the explorer view and reveals the active Deepnote notebook', async () => {
+            stubActiveNotebook(notebookMetadata);
+
+            await handlerFor(Commands.RevealDeepnoteExplorer)();
+
+            verify(mockedVSCodeNamespaces.commands.executeCommand(EXPLORER_FOCUS_COMMAND)).once();
+            assert.deepStrictEqual(findTreeItem.firstCall.args, ['project-1', 'notebook-1']);
+            assert.deepStrictEqual(reveal.firstCall.args, [treeItem, { select: true, focus: true, expand: true }]);
+        });
+
+        test('only focuses the explorer view when no notebook editor is active', async () => {
+            await handlerFor(Commands.RevealDeepnoteExplorer)();
+
+            verify(mockedVSCodeNamespaces.commands.executeCommand(EXPLORER_FOCUS_COMMAND)).once();
+            assert.isFalse(findTreeItem.called);
+            assert.isFalse(reveal.called);
+            verify(mockedVSCodeNamespaces.window.showInformationMessage(anything())).never();
+            verify(mockedVSCodeNamespaces.window.showWarningMessage(anything())).never();
+        });
+
+        test('only focuses the explorer view when the active notebook is not a Deepnote notebook', async () => {
+            stubActiveNotebook(notebookMetadata, 'jupyter-notebook');
+
+            await handlerFor(Commands.RevealDeepnoteExplorer)();
+
+            verify(mockedVSCodeNamespaces.commands.executeCommand(EXPLORER_FOCUS_COMMAND)).once();
+            assert.isFalse(findTreeItem.called);
+            assert.isFalse(reveal.called);
+        });
+
+        test('only focuses the explorer view when the active notebook has no Deepnote metadata', async () => {
+            stubActiveNotebook({});
+
+            await handlerFor(Commands.RevealDeepnoteExplorer)();
+
+            verify(mockedVSCodeNamespaces.commands.executeCommand(EXPLORER_FOCUS_COMMAND)).once();
+            assert.isFalse(findTreeItem.called);
+            verify(mockedVSCodeNamespaces.window.showWarningMessage(anything())).never();
+        });
+
+        test('does not reveal or notify when the notebook is not in the tree yet', async () => {
+            stubActiveNotebook(notebookMetadata);
+            findTreeItem.resolves(undefined);
+
+            await handlerFor(Commands.RevealDeepnoteExplorer)();
+
+            verify(mockedVSCodeNamespaces.commands.executeCommand(EXPLORER_FOCUS_COMMAND)).once();
+            assert.isFalse(reveal.called);
+            verify(mockedVSCodeNamespaces.window.showInformationMessage(anything())).never();
+        });
+
+        test('swallows reveal failures without notifying the user', async () => {
+            stubActiveNotebook(notebookMetadata);
+            reveal.rejects(new Error('tree not loaded'));
+
+            await handlerFor(Commands.RevealDeepnoteExplorer)();
+
+            verify(mockedVSCodeNamespaces.commands.executeCommand(EXPLORER_FOCUS_COMMAND)).once();
+            verify(mockedVSCodeNamespaces.window.showInformationMessage(anything())).never();
+        });
+
+        test('still reveals the active notebook when focusing the view fails', async () => {
+            stubActiveNotebook(notebookMetadata);
+            when(mockedVSCodeNamespaces.commands.executeCommand(EXPLORER_FOCUS_COMMAND)).thenReject(
+                new Error('no such command')
+            );
+
+            await handlerFor(Commands.RevealDeepnoteExplorer)();
+
+            assert.deepStrictEqual(reveal.firstCall.args, [treeItem, { select: true, focus: true, expand: true }]);
         });
     });
 

--- a/src/platform/common/constants.ts
+++ b/src/platform/common/constants.ts
@@ -222,6 +222,7 @@ export namespace Commands {
     export const OpenDeepnoteNotebook = 'deepnote.openNotebook';
     export const OpenDeepnoteFile = 'deepnote.openFile';
     export const RevealInDeepnoteExplorer = 'deepnote.revealInExplorer';
+    export const RevealDeepnoteExplorer = 'deepnote.revealExplorer';
     export const CopyNotebookDetails = 'deepnote.copyNotebookDetails';
     export const EnableSnapshots = 'deepnote.enableSnapshots';
     export const DisableSnapshots = 'deepnote.disableSnapshots';


### PR DESCRIPTION
## Summary

Users who open a `.deepnote` file from the VS Code file explorer frequently never find the Deepnote view container or its project explorer tree (#217). This adds a dedicated **Show Project Explorer** button to the Deepnote notebook toolbar, backed by a new `deepnote.revealExplorer` command.

Closes #217

## What the user sees

- A new `$(list-tree)` **Show Project Explorer** button as the first item on the notebook toolbar (`notebook/toolbar`, `navigation@-2`, `when: notebookType == 'deepnote'`) — to the left of the existing **Open in Deepnote** button. When the global notebook toolbar is disabled (`notebook.globalToolbar == false`) the same button appears in `editor/title` instead, matching how the repo already handles that setting for its other notebook buttons.
- Clicking it opens the Deepnote view container (even if the sidebar is hidden or the container has never been opened), focuses the **Explorer** tree, and selects/expands the currently active notebook in the tree.
- The command is also available from the palette as `Deepnote: Show Project Explorer`. Run without an active Deepnote notebook it simply opens the explorer.

## Design notes

- **Relationship to the existing `deepnote.revealInExplorer`** (`Deepnote: Reveal in Explorer`). That command already reveals the active notebook, but it is designed as a *locate this notebook* action: it is an inline action on tree items, and it shows toasts when there is no active Deepnote notebook, when metadata is missing, or when the item cannot be found (behaviour covered by `test/e2e/suite/workspace/revealInExplorer.e2e.test.ts`). A toolbar button whose job is *show me the sidebar* must not pop those toasts (e.g. while the tree is still loading), and must open the view container even when nothing can be revealed. Rather than change the semantics of the existing command, this PR adds `deepnote.revealExplorer` next to it and extracts the shared `findTreeItem` + `TreeView.reveal` step into a private `revealNotebookInTree` helper used by both, so there is one reveal path and no duplicated logic. `revealInExplorer` behaves exactly as before.
- The view is focused via `commands.executeCommand('deepnoteExplorer.focus')` — the command VS Code auto-registers for every contributed view — before revealing. The active notebook editor is captured before focus moves to the sidebar. Failures to focus or to reveal are logged, never surfaced.
- `deepnoteExplorer` was already a bare string literal in `createTreeView`; it now lives in a module constant shared with the focus command id.
- Scope: touches only `src/notebooks/deepnote/deepnoteExplorerView.ts`, `src/platform/common/constants.ts`, the `commands`/`menus` sections of `package.json`, `package.nls.json` and two doc tables. It does **not** touch `src/kernels/deepnote/` or the kernel/environments parts of `package.json`, so it does not overlap with #376. The `notebook/toolbar` insertion sits above the existing `deepnote.openInDeepnote` entry; #509 edits add-block entries further down the same array, so any conflict would be a trivial adjacency merge.

## Testing

- `npm run compile-tsc` — clean
- `npm run test:unittests` — 2778 passing, 234 pending; new `revealExplorer` suite (7 tests) in `src/notebooks/deepnote/deepnoteExplorerView.unit.test.ts` covers: focus + reveal of the active notebook, focus-only when no notebook editor / a non-Deepnote notebook / missing metadata, no toast when the item is not in the tree yet, swallowed reveal failures, and reveal still happening if the focus command rejects
- `npm run typecheck` — 0 errors
- `npm run lint` — exit 0 (pre-existing warnings only, none in changed files)
- `npm run format` — clean
- `npm run spell-check` — 0 issues
- Not run: E2E (`npm run test:e2e`). A follow-up could add an ExTester case mirroring `revealInExplorer.e2e.test.ts` that clicks the toolbar button with the sidebar closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Show Project Explorer” command for Deepnote notebooks.
  - The command focuses the Deepnote Explorer and selects the active notebook when available.
  - Added access from notebook editor titles and notebook toolbars.
  - Editor-title access is hidden when the global notebook toolbar is enabled.
- **Documentation**
  - Clarified command palette and Explorer documentation, including active notebook selection behavior.
- **Tests**
  - Added coverage for Explorer focusing, notebook selection, unavailable notebooks, and reveal failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->