### PR TITLE
feat(sql): add a status bar toggle for SQL query chaining (return type)

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,12 @@
                 "icon": "$(database)"
             },
             {
+                "command": "deepnote.setSqlReturnVariableType",
+                "title": "%deepnote.commands.setSqlReturnVariableType.title%",
+                "category": "Deepnote",
+                "enablement": "notebookType == 'deepnote'"
+            },
+            {
                 "command": "deepnote.addBigNumberChartBlock",
                 "title": "%deepnote.commands.addBigNumberChartBlock.title%",
                 "category": "Deepnote",
@@ -1230,6 +1236,10 @@
                 {
                     "command": "deepnote.interactive.copyCell",
                     "when": "false"
+                },
+                {
+                    "command": "deepnote.setSqlReturnVariableType",
+                    "when": "notebookType == 'deepnote'"
                 },
                 {
                     "command": "deepnote.exportAsPythonScript",

--- a/package.nls.json
+++ b/package.nls.json
@@ -262,6 +262,7 @@
     "deepnote.commands.importJupyterNotebook.title": "Import Jupyter Notebook",
     "deepnote.commands.addAgentBlock.title": "Add Agent Block",
     "deepnote.commands.addSqlBlock.title": "Add SQL Block",
+    "deepnote.commands.setSqlReturnVariableType.title": "Set SQL Block Return Type",
     "deepnote.commands.addBigNumberChartBlock.title": "Add Big Number Block",
     "deepnote.commands.addChartBlock.title": "Add Chart Block",
     "deepnote.commands.addInputTextBlock.title": "Add Input Text Block",

--- a/src/notebooks/deepnote/sqlCellStatusBarProvider.ts
+++ b/src/notebooks/deepnote/sqlCellStatusBarProvider.ts
@@ -342,7 +342,9 @@ export class SqlCellStatusBarProvider implements NotebookCellStatusBarItemProvid
 
     /**
      * The cell a status bar command acts on: the one it was invoked with, else the active notebook cell (command
-     * palette). Reports an error and returns `undefined` when neither exists.
+     * palette). The palette entry is gated on the notebook type only, so the active cell is used only when it is a
+     * SQL cell; the metadata these commands write has no meaning on any other cell. Reports an error and returns
+     * `undefined` when there is no SQL cell to act on.
      */
     private resolveTargetCell(cell?: NotebookCell): NotebookCell | undefined {
         if (cell) {
@@ -351,10 +353,13 @@ export class SqlCellStatusBarProvider implements NotebookCellStatusBarItemProvid
 
         const activeEditor = window.activeNotebookEditor;
         if (activeEditor && activeEditor.selection) {
-            return activeEditor.notebook.cellAt(activeEditor.selection.start);
+            const activeCell = activeEditor.notebook.cellAt(activeEditor.selection.start);
+            if (activeCell.document.languageId === 'sql') {
+                return activeCell;
+            }
         }
 
-        void window.showErrorMessage(l10n.t('No active notebook cell'));
+        void window.showErrorMessage(l10n.t('No active SQL cell'));
 
         return undefined;
     }

--- a/src/notebooks/deepnote/sqlCellStatusBarProvider.ts
+++ b/src/notebooks/deepnote/sqlCellStatusBarProvider.ts
@@ -33,7 +33,8 @@ import { persistProjectIntegrations } from './integrations/projectIntegrationsWr
 import { IDeepnoteNotebookManager, ProjectIntegration } from '../types';
 import { logger } from '../../platform/logging';
 import { ISqlIntegrationEnvVarsProvider } from '../../platform/notebooks/deepnote/types';
-import type { DeepnoteFile } from '@deepnote/blocks';
+import { SqlReturnVariableType } from '../../platform/common/utils/localize';
+import type { DeepnoteFile, SqlCellVariableType } from '@deepnote/blocks';
 import {
     DatabaseIntegrationConfig,
     DatabaseIntegrationType,
@@ -49,6 +50,24 @@ type RawProjectIntegration = NonNullable<DeepnoteFile['project']['integrations']
 interface LocalQuickPickItem extends QuickPickItem {
     id: string;
 }
+
+/** QuickPick item for one SQL return type */
+interface ReturnVariableTypeQuickPickItem extends QuickPickItem {
+    returnVariableType: SqlCellVariableType;
+}
+
+/** What a SQL block returns when `deepnote_return_variable_type` is absent or unrecognized. */
+const DEFAULT_RETURN_VARIABLE_TYPE: SqlCellVariableType = 'dataframe';
+
+const returnVariableTypeLabels: Record<SqlCellVariableType, string> = {
+    dataframe: SqlReturnVariableType.dataframeLabel,
+    query_preview: SqlReturnVariableType.queryPreviewLabel
+};
+
+const returnVariableTypeDetails: Record<SqlCellVariableType, string> = {
+    dataframe: SqlReturnVariableType.dataframeDetail,
+    query_preview: SqlReturnVariableType.queryPreviewDetail
+};
 
 const integrationTypeLabels: Record<ConfigurableDatabaseIntegrationType, string> = {
     alloydb: l10n.t('Google AlloyDB'),
@@ -72,7 +91,7 @@ const integrationTypeLabels: Record<ConfigurableDatabaseIntegrationType, string>
 };
 
 /**
- * Provides status bar items for SQL cells showing the integration name and variable name
+ * Provides status bar items for SQL cells showing the integration name, variable name and return type
  */
 @injectable()
 export class SqlCellStatusBarProvider implements NotebookCellStatusBarItemProvider, IExtensionSyncActivationService {
@@ -112,40 +131,30 @@ export class SqlCellStatusBarProvider implements NotebookCellStatusBarItemProvid
         // Register command to update SQL variable name
         this.disposables.push(
             commands.registerCommand('deepnote.updateSqlVariableName', async (cell?: NotebookCell) => {
-                if (!cell) {
-                    // Fall back to the active notebook cell
-                    const activeEditor = window.activeNotebookEditor;
-                    if (activeEditor && activeEditor.selection) {
-                        cell = activeEditor.notebook.cellAt(activeEditor.selection.start);
-                    }
+                const targetCell = this.resolveTargetCell(cell);
+                if (targetCell) {
+                    await this.updateVariableName(targetCell);
                 }
-
-                if (!cell) {
-                    void window.showErrorMessage(l10n.t('No active notebook cell'));
-                    return;
-                }
-
-                await this.updateVariableName(cell);
             })
         );
 
         // Register command to switch SQL integration
         this.disposables.push(
             commands.registerCommand('deepnote.switchSqlIntegration', async (cell?: NotebookCell) => {
-                if (!cell) {
-                    // Fall back to the active notebook cell
-                    const activeEditor = window.activeNotebookEditor;
-                    if (activeEditor && activeEditor.selection) {
-                        cell = activeEditor.notebook.cellAt(activeEditor.selection.start);
-                    }
+                const targetCell = this.resolveTargetCell(cell);
+                if (targetCell) {
+                    await this.switchIntegration(targetCell);
                 }
+            })
+        );
 
-                if (!cell) {
-                    void window.showErrorMessage(l10n.t('No active notebook cell'));
-                    return;
+        // Register command to choose what a SQL block returns (DataFrame vs. query preview for chaining)
+        this.disposables.push(
+            commands.registerCommand('deepnote.setSqlReturnVariableType', async (cell?: NotebookCell) => {
+                const targetCell = this.resolveTargetCell(cell);
+                if (targetCell) {
+                    await this.setReturnVariableType(targetCell);
                 }
-
-                await this.switchIntegration(cell);
             })
         );
 
@@ -209,6 +218,9 @@ export class SqlCellStatusBarProvider implements NotebookCellStatusBarItemProvid
 
         // Always add variable status bar item for SQL cells
         items.push(this.createVariableStatusBarItem(cell));
+
+        // Always add the return type item: it is what makes query chaining reachable from the UI
+        items.push(this.createReturnVariableTypeStatusBarItem(cell));
 
         return items;
     }
@@ -288,6 +300,34 @@ export class SqlCellStatusBarProvider implements NotebookCellStatusBarItemProvid
         };
     }
 
+    private createReturnVariableTypeStatusBarItem(cell: NotebookCell): NotebookCellStatusBarItem {
+        const returnVariableType = this.getReturnVariableType(cell);
+
+        return {
+            text: SqlReturnVariableType.statusBarText(returnVariableTypeLabels[returnVariableType]),
+            alignment: 1, // NotebookCellStatusBarAlignment.Left
+            priority: 80,
+            tooltip: SqlReturnVariableType.statusBarTooltip,
+            command: {
+                title: SqlReturnVariableType.changeCommandTitle,
+                command: 'deepnote.setSqlReturnVariableType',
+                arguments: [cell]
+            }
+        };
+    }
+
+    private getReturnVariableType(cell: NotebookCell): SqlCellVariableType {
+        const metadata = cell.metadata;
+        if (metadata && typeof metadata === 'object') {
+            const returnVariableType = (metadata as Record<string, unknown>).deepnote_return_variable_type;
+            if (returnVariableType === 'query_preview') {
+                return returnVariableType;
+            }
+        }
+
+        return DEFAULT_RETURN_VARIABLE_TYPE;
+    }
+
     private getVariableName(cell: NotebookCell): string {
         const metadata = cell.metadata;
         if (metadata && typeof metadata === 'object') {
@@ -298,6 +338,77 @@ export class SqlCellStatusBarProvider implements NotebookCellStatusBarItemProvid
         }
 
         return 'df';
+    }
+
+    /**
+     * The cell a status bar command acts on: the one it was invoked with, else the active notebook cell (command
+     * palette). Reports an error and returns `undefined` when neither exists.
+     */
+    private resolveTargetCell(cell?: NotebookCell): NotebookCell | undefined {
+        if (cell) {
+            return cell;
+        }
+
+        const activeEditor = window.activeNotebookEditor;
+        if (activeEditor && activeEditor.selection) {
+            return activeEditor.notebook.cellAt(activeEditor.selection.start);
+        }
+
+        void window.showErrorMessage(l10n.t('No active notebook cell'));
+
+        return undefined;
+    }
+
+    /**
+     * Lets the user pick what the block assigns to its variable. `query_preview` is what enables SQL query
+     * chaining: the toolkit returns a lazy `DeepnoteQueryPreview`, and a later SQL block that references the
+     * variable has this block's query inlined as a CTE instead of a materialized DataFrame.
+     */
+    private async setReturnVariableType(cell: NotebookCell): Promise<void> {
+        const currentReturnVariableType = this.getReturnVariableType(cell);
+
+        const items: ReturnVariableTypeQuickPickItem[] = (['dataframe', 'query_preview'] as const).map(
+            (returnVariableType) => ({
+                label: returnVariableTypeLabels[returnVariableType],
+                description:
+                    returnVariableType === currentReturnVariableType
+                        ? SqlReturnVariableType.currentlySelected
+                        : undefined,
+                detail: returnVariableTypeDetails[returnVariableType],
+                returnVariableType
+            })
+        );
+
+        const selected = await window.showQuickPick(items, {
+            placeHolder: SqlReturnVariableType.pickerPlaceholder
+        });
+
+        if (!selected || selected.returnVariableType === currentReturnVariableType) {
+            return;
+        }
+
+        // Update cell metadata; the serializer persists it to the .deepnote file
+        const edit = new WorkspaceEdit();
+        const updatedMetadata = {
+            ...cell.metadata,
+            deepnote_return_variable_type: selected.returnVariableType
+        };
+
+        edit.set(cell.notebook.uri, [NotebookEdit.updateCellMetadata(cell.index, updatedMetadata)]);
+
+        const success = await workspace.applyEdit(edit);
+        if (!success) {
+            void window.showErrorMessage(SqlReturnVariableType.updateFailed);
+            return;
+        }
+
+        // Trigger status bar update
+        this._onDidChangeCellStatusBarItems.fire();
+
+        this.analytics.trackEvent({
+            eventName: 'switch_sql_return_variable_type',
+            properties: { returnVariableType: selected.returnVariableType }
+        });
     }
 
     private async updateVariableName(cell: NotebookCell): Promise<void> {

--- a/src/notebooks/deepnote/sqlCellStatusBarProvider.unit.test.ts
+++ b/src/notebooks/deepnote/sqlCellStatusBarProvider.unit.test.ts
@@ -74,7 +74,7 @@ suite('SqlCellStatusBarProvider', () => {
         assert.isDefined(result);
         assert.isArray(result);
         const items = result as any[];
-        assert.strictEqual(items.length, 2);
+        assert.strictEqual(items.length, 3);
 
         // Check "No integration connected" status bar item
         const integrationItem = items[0];
@@ -93,6 +93,47 @@ suite('SqlCellStatusBarProvider', () => {
         assert.strictEqual(variableItem.command.command, 'deepnote.updateSqlVariableName');
         assert.deepStrictEqual(variableItem.command.arguments, [cell]);
         assert.strictEqual(variableItem.priority, 90);
+
+        // Check return type status bar item (defaults to DataFrame when the metadata is absent)
+        const returnTypeItem = items[2];
+        assert.strictEqual(returnTypeItem.text, 'Return: DataFrame');
+        assert.strictEqual(returnTypeItem.alignment, 1);
+        assert.isDefined(returnTypeItem.command);
+        assert.strictEqual(returnTypeItem.command.command, 'deepnote.setSqlReturnVariableType');
+        assert.deepStrictEqual(returnTypeItem.command.arguments, [cell]);
+        assert.strictEqual(returnTypeItem.priority, 80);
+        assert.include(returnTypeItem.tooltip, 'Query preview');
+        assert.include(returnTypeItem.tooltip, 'chained');
+    });
+
+    test('shows Query preview return type when metadata selects query_preview', async () => {
+        const cell = createMockCell({
+            languageId: 'sql',
+            metadata: {
+                sql_integration_id: DATAFRAME_SQL_INTEGRATION_ID,
+                deepnote_return_variable_type: 'query_preview'
+            }
+        });
+
+        const result = await provider.provideCellStatusBarItems(cell, cancellationToken);
+
+        const items = result as any[];
+        assert.strictEqual(items.length, 3);
+        assert.strictEqual(items[2].text, 'Return: Query preview');
+        assert.strictEqual(items[2].command.command, 'deepnote.setSqlReturnVariableType');
+        assert.deepStrictEqual(items[2].command.arguments, [cell]);
+    });
+
+    test('falls back to DataFrame return type for an unrecognized metadata value', async () => {
+        const cell = createMockCell({
+            languageId: 'sql',
+            metadata: { sql_integration_id: DATAFRAME_SQL_INTEGRATION_ID, deepnote_return_variable_type: 'not-a-type' }
+        });
+
+        const result = await provider.provideCellStatusBarItems(cell, cancellationToken);
+
+        const items = result as any[];
+        assert.strictEqual(items[2].text, 'Return: DataFrame');
     });
 
     test('returns status bar items for SQL cells with dataframe integration ID', async () => {
@@ -106,7 +147,7 @@ suite('SqlCellStatusBarProvider', () => {
         assert.isDefined(result);
         assert.isArray(result);
         const items = result as any[];
-        assert.strictEqual(items.length, 2);
+        assert.strictEqual(items.length, 3);
 
         // Check integration status bar item
         const integrationItem = items[0];
@@ -158,7 +199,7 @@ suite('SqlCellStatusBarProvider', () => {
         assert.isDefined(result);
         assert.isArray(result);
         const items = result as any[];
-        assert.strictEqual(items.length, 2);
+        assert.strictEqual(items.length, 3);
 
         // Check integration status bar item
         const integrationItem = items[0];
@@ -279,7 +320,7 @@ suite('SqlCellStatusBarProvider', () => {
         assert.isDefined(result);
         assert.isArray(result);
         const items = result as any[];
-        assert.strictEqual(items.length, 2);
+        assert.strictEqual(items.length, 3);
         assert.strictEqual(items[0].text, '$(database) Unknown integration (configure)');
         assert.strictEqual(items[0].alignment, 1);
         assert.strictEqual(items[0].command.command, 'deepnote.switchSqlIntegration');
@@ -316,7 +357,7 @@ suite('SqlCellStatusBarProvider', () => {
         assert.isDefined(result);
         assert.isArray(result);
         const items = result as any[];
-        assert.strictEqual(items.length, 2);
+        assert.strictEqual(items.length, 3);
         assert.strictEqual(items[0].text, '$(database) Production Database (configure)');
         assert.strictEqual(items[0].alignment, 1);
         assert.strictEqual(items[0].command.command, 'deepnote.switchSqlIntegration');
@@ -339,7 +380,7 @@ suite('SqlCellStatusBarProvider', () => {
         assert.isDefined(result);
         assert.isArray(result);
         const items = result as any[];
-        assert.strictEqual(items.length, 1);
+        assert.strictEqual(items.length, 2);
 
         // Check variable status bar item is still shown
         const variableItem = items[0];
@@ -380,7 +421,7 @@ suite('SqlCellStatusBarProvider', () => {
         assert.isDefined(result);
         assert.isArray(result);
         const items = result as any[];
-        assert.strictEqual(items.length, 2);
+        assert.strictEqual(items.length, 3);
 
         // Check variable status bar item shows custom name
         const variableItem = items[1];
@@ -433,6 +474,67 @@ suite('SqlCellStatusBarProvider', () => {
             activateProvider.activate();
 
             verify(mockedVSCodeNamespaces.commands.registerCommand('deepnote.switchSqlIntegration', anything())).once();
+        });
+
+        test('registers deepnote.setSqlReturnVariableType command', () => {
+            activateProvider.activate();
+
+            verify(
+                mockedVSCodeNamespaces.commands.registerCommand('deepnote.setSqlReturnVariableType', anything())
+            ).once();
+        });
+
+        test('setSqlReturnVariableType command handler falls back to active cell when no cell provided', async () => {
+            let commandHandler: ((cell?: NotebookCell) => Promise<void>) | undefined;
+            when(
+                mockedVSCodeNamespaces.commands.registerCommand('deepnote.setSqlReturnVariableType', anything())
+            ).thenCall((_name, handler) => {
+                commandHandler = handler;
+                return { dispose: () => undefined };
+            });
+
+            const cell = createMockCell({ languageId: 'sql' });
+            when(mockedVSCodeNamespaces.window.activeNotebookEditor).thenReturn({
+                notebook: {
+                    cellAt: (_index: number) => cell
+                },
+                selection: { start: 0 }
+            } as any);
+            when(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).thenReturn(
+                Promise.resolve({ label: 'Query preview', returnVariableType: 'query_preview' } as any)
+            );
+            when(mockedVSCodeNamespaces.workspace.applyEdit(anything())).thenReturn(Promise.resolve(true));
+
+            activateProvider.activate();
+            assert.isDefined(commandHandler, 'Command handler should be registered');
+
+            // Invoke the handler without a cell argument
+            await commandHandler!();
+
+            // Verify that the active cell was used
+            verify(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).once();
+            verify(mockedVSCodeNamespaces.workspace.applyEdit(anything())).once();
+        });
+
+        test('setSqlReturnVariableType command handler shows error when no cell and no active editor', async () => {
+            let commandHandler: ((cell?: NotebookCell) => Promise<void>) | undefined;
+            when(
+                mockedVSCodeNamespaces.commands.registerCommand('deepnote.setSqlReturnVariableType', anything())
+            ).thenCall((_name, handler) => {
+                commandHandler = handler;
+                return { dispose: () => undefined };
+            });
+
+            when(mockedVSCodeNamespaces.window.activeNotebookEditor).thenReturn(undefined);
+            when(mockedVSCodeNamespaces.window.showErrorMessage(anything())).thenReturn(Promise.resolve(undefined));
+
+            activateProvider.activate();
+            assert.isDefined(commandHandler, 'Command handler should be registered');
+
+            await commandHandler!();
+
+            verify(mockedVSCodeNamespaces.window.showErrorMessage(anything())).once();
+            verify(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).never();
         });
 
         test('updateSqlVariableName command handler falls back to active cell when no cell provided', async () => {
@@ -1451,6 +1553,177 @@ suite('SqlCellStatusBarProvider', () => {
 
             verify(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).once();
             verify(mockedVSCodeNamespaces.workspace.applyEdit(anything())).never();
+        });
+    });
+
+    suite('setSqlReturnVariableType command handler', () => {
+        let commandDisposables: IDisposableRegistry;
+        let commandProvider: SqlCellStatusBarProvider;
+        let commandTelemetry: ITelemetryService;
+        let setReturnVariableTypeHandler: Function;
+
+        setup(() => {
+            resetVSCodeMocks();
+            commandDisposables = [];
+            commandTelemetry = mock<ITelemetryService>();
+            commandProvider = new SqlCellStatusBarProvider(
+                commandDisposables,
+                instance(mock<IIntegrationStorage>()),
+                instance(mock<IDeepnoteNotebookManager>()),
+                instance(commandTelemetry),
+                emptySqlIntegrationEnvVars()
+            );
+
+            // Capture the command handler
+            when(
+                mockedVSCodeNamespaces.commands.registerCommand('deepnote.setSqlReturnVariableType', anything())
+            ).thenCall((_, handler) => {
+                setReturnVariableTypeHandler = handler;
+                return {
+                    dispose: () => {
+                        return;
+                    }
+                };
+            });
+
+            commandProvider.activate();
+        });
+
+        teardown(() => {
+            resetVSCodeMocks();
+        });
+
+        test('offers DataFrame and Query preview, marking the current one', async () => {
+            const cell = createMockCell({
+                languageId: 'sql',
+                metadata: { deepnote_return_variable_type: 'query_preview' }
+            });
+
+            when(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).thenReturn(
+                Promise.resolve(undefined)
+            );
+
+            await setReturnVariableTypeHandler(cell);
+
+            const [items, options] = capture(mockedVSCodeNamespaces.window.showQuickPick).last();
+            assert.deepStrictEqual(
+                (items as any[]).map((item) => ({
+                    label: item.label,
+                    description: item.description,
+                    returnVariableType: item.returnVariableType
+                })),
+                [
+                    { label: 'DataFrame', description: undefined, returnVariableType: 'dataframe' },
+                    { label: 'Query preview', description: 'Currently selected', returnVariableType: 'query_preview' }
+                ]
+            );
+            assert.isNotEmpty((items as any[])[0].detail);
+            assert.isNotEmpty((items as any[])[1].detail);
+            assert.strictEqual((options as any).placeHolder, 'Select what this SQL block returns');
+        });
+
+        test('switches a DataFrame block to query preview and reports it', async () => {
+            const cell = createMockCell({
+                languageId: 'sql',
+                metadata: { deepnote_variable_name: 'df_1', deepnote_return_variable_type: 'dataframe' }
+            });
+
+            when(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).thenReturn(
+                Promise.resolve({ label: 'Query preview', returnVariableType: 'query_preview' } as any)
+            );
+            when(mockedVSCodeNamespaces.workspace.applyEdit(anything())).thenReturn(Promise.resolve(true));
+
+            const statusBarChangeHandler = createEventHandler(
+                commandProvider,
+                'onDidChangeCellStatusBarItems',
+                commandDisposables
+            );
+
+            await setReturnVariableTypeHandler(cell);
+
+            verify(mockedVSCodeNamespaces.workspace.applyEdit(anything())).once();
+            assert.strictEqual(statusBarChangeHandler.count, 1, 'onDidChangeCellStatusBarItems should fire once');
+            verify(
+                commandTelemetry.trackEvent(
+                    deepEqual({
+                        eventName: 'switch_sql_return_variable_type',
+                        properties: { returnVariableType: 'query_preview' }
+                    })
+                )
+            ).once();
+        });
+
+        test('switches a query preview block back to DataFrame', async () => {
+            const cell = createMockCell({
+                languageId: 'sql',
+                metadata: { deepnote_return_variable_type: 'query_preview' }
+            });
+
+            when(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).thenReturn(
+                Promise.resolve({ label: 'DataFrame', returnVariableType: 'dataframe' } as any)
+            );
+            when(mockedVSCodeNamespaces.workspace.applyEdit(anything())).thenReturn(Promise.resolve(true));
+
+            await setReturnVariableTypeHandler(cell);
+
+            verify(mockedVSCodeNamespaces.workspace.applyEdit(anything())).once();
+            verify(
+                commandTelemetry.trackEvent(
+                    deepEqual({
+                        eventName: 'switch_sql_return_variable_type',
+                        properties: { returnVariableType: 'dataframe' }
+                    })
+                )
+            ).once();
+        });
+
+        test('does not update if user dismisses the picker', async () => {
+            const cell = createMockCell({ languageId: 'sql' });
+
+            when(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).thenReturn(
+                Promise.resolve(undefined)
+            );
+
+            await setReturnVariableTypeHandler(cell);
+
+            verify(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).once();
+            verify(mockedVSCodeNamespaces.workspace.applyEdit(anything())).never();
+            verify(commandTelemetry.trackEvent(anything())).never();
+        });
+
+        test('does not update if the current return type is picked again', async () => {
+            // No metadata at all resolves to DataFrame, so picking DataFrame is a no-op.
+            const cell = createMockCell({ languageId: 'sql' });
+
+            when(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).thenReturn(
+                Promise.resolve({ label: 'DataFrame', returnVariableType: 'dataframe' } as any)
+            );
+
+            await setReturnVariableTypeHandler(cell);
+
+            verify(mockedVSCodeNamespaces.workspace.applyEdit(anything())).never();
+            verify(commandTelemetry.trackEvent(anything())).never();
+        });
+
+        test('shows error message and reports nothing if workspace edit fails', async () => {
+            const cell = createMockCell({ languageId: 'sql' });
+
+            when(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).thenReturn(
+                Promise.resolve({ label: 'Query preview', returnVariableType: 'query_preview' } as any)
+            );
+            when(mockedVSCodeNamespaces.workspace.applyEdit(anything())).thenReturn(Promise.resolve(false));
+
+            const statusBarChangeHandler = createEventHandler(
+                commandProvider,
+                'onDidChangeCellStatusBarItems',
+                commandDisposables
+            );
+
+            await setReturnVariableTypeHandler(cell);
+
+            verify(mockedVSCodeNamespaces.window.showErrorMessage('Failed to update the SQL return type')).once();
+            assert.strictEqual(statusBarChangeHandler.count, 0);
+            verify(commandTelemetry.trackEvent(anything())).never();
         });
     });
 });

--- a/src/notebooks/deepnote/sqlCellStatusBarProvider.unit.test.ts
+++ b/src/notebooks/deepnote/sqlCellStatusBarProvider.unit.test.ts
@@ -516,6 +516,35 @@ suite('SqlCellStatusBarProvider', () => {
             verify(mockedVSCodeNamespaces.workspace.applyEdit(anything())).once();
         });
 
+        test('setSqlReturnVariableType command handler shows error when the active cell is not a SQL cell', async () => {
+            let commandHandler: ((cell?: NotebookCell) => Promise<void>) | undefined;
+            when(
+                mockedVSCodeNamespaces.commands.registerCommand('deepnote.setSqlReturnVariableType', anything())
+            ).thenCall((_name, handler) => {
+                commandHandler = handler;
+                return { dispose: () => undefined };
+            });
+
+            const pythonCell = createMockCell({ languageId: 'python' });
+            when(mockedVSCodeNamespaces.window.activeNotebookEditor).thenReturn({
+                notebook: {
+                    cellAt: (_index: number) => pythonCell
+                },
+                selection: { start: 0 }
+            } as any);
+            when(mockedVSCodeNamespaces.window.showErrorMessage(anything())).thenReturn(Promise.resolve(undefined));
+
+            activateProvider.activate();
+            assert.isDefined(commandHandler, 'Command handler should be registered');
+
+            await commandHandler!();
+
+            // The return type must never be written to a non-SQL cell
+            verify(mockedVSCodeNamespaces.window.showErrorMessage(anything())).once();
+            verify(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).never();
+            verify(mockedVSCodeNamespaces.workspace.applyEdit(anything())).never();
+        });
+
         test('setSqlReturnVariableType command handler shows error when no cell and no active editor', async () => {
             let commandHandler: ((cell?: NotebookCell) => Promise<void>) | undefined;
             when(

--- a/src/platform/analytics/types.ts
+++ b/src/platform/analytics/types.ts
@@ -27,6 +27,7 @@ export type TelemetryEventName =
     | 'select_environment'
     | 'split_notebook'
     | 'switch_sql_integration'
+    | 'switch_sql_return_variable_type'
     | 'toggle_snapshots'
     | 'update_environment';
 
@@ -74,6 +75,7 @@ export interface TelemetryEventProperties {
     split_notebook: { notebookCount: number; outcome: CommandOutcome };
     /** `fromEnvFile` is file-ONLY, not file-configured: false when the id is also in the project roster. */
     switch_sql_integration: { fromEnvFile: boolean; integrationType: string };
+    switch_sql_return_variable_type: { returnVariableType: 'dataframe' | 'query_preview' };
     toggle_snapshots: { enabled: boolean };
     update_environment: { field: 'name' | 'packages'; packageCount?: number };
 }

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -814,6 +814,23 @@ export namespace WebViews {
     export const dataframeExportTable = l10n.t('Export table');
 }
 
+export namespace SqlReturnVariableType {
+    export const dataframeLabel = l10n.t('DataFrame');
+    export const queryPreviewLabel = l10n.t('Query preview');
+    export const statusBarText = (label: string) => l10n.t('Return: {0}', label);
+    export const statusBarTooltip = l10n.t(
+        'What this SQL block assigns to its variable.\nDataFrame runs the query and materializes the full result.\nQuery preview keeps a lazy reference to the query (with a 100-row preview) that later SQL blocks can query directly, so they are chained into a single query.\nClick to change'
+    );
+    export const dataframeDetail = l10n.t('Run the query and store the full result as a pandas DataFrame');
+    export const queryPreviewDetail = l10n.t(
+        'Keep a lazy reference to the query so later SQL blocks can chain onto it (100-row preview)'
+    );
+    export const currentlySelected = l10n.t('Currently selected');
+    export const pickerPlaceholder = l10n.t('Select what this SQL block returns');
+    export const changeCommandTitle = l10n.t('Change Return Type');
+    export const updateFailed = l10n.t('Failed to update the SQL return type');
+}
+
 export namespace Integrations {
     export const title = l10n.t('Deepnote Integrations');
     export const noIntegrationsFound = l10n.t('No integrations found in this project.');

--- a/test/e2e/fixtures/sql-query-chaining.deepnote
+++ b/test/e2e/fixtures/sql-query-chaining.deepnote
@@ -1,0 +1,32 @@
+version: '1.0.0'
+metadata:
+  createdAt: '2025-01-01T00:00:00.000Z'
+  modifiedAt: '2025-01-01T00:00:00.000Z'
+project:
+  id: e2e-sql-query-chaining-project
+  name: E2E SQL Query Chaining
+  notebooks:
+    - id: e2e-sql-query-chaining-notebook
+      name: SQL Query Chaining
+      blocks:
+        - id: e2e-sql-source-block
+          blockGroup: e2e-sql-source-group
+          type: sql
+          content: SELECT range AS id FROM range(1234)
+          sortingKey: a0
+          metadata:
+            deepnote_variable_name: source_rows
+            deepnote_return_variable_type: dataframe
+            sql_integration_id: deepnote-dataframe-sql
+        - id: e2e-sql-chained-block
+          blockGroup: e2e-sql-chained-group
+          type: sql
+          content: SELECT 'chained_rows_' || COUNT(*) AS chained_marker FROM source_rows
+          sortingKey: a1
+          metadata:
+            deepnote_variable_name: chained_rows
+            deepnote_return_variable_type: dataframe
+            sql_integration_id: deepnote-dataframe-sql
+      executionMode: block
+      isModule: false
+  settings: {}

--- a/test/e2e/helpers/notebook.ts
+++ b/test/e2e/helpers/notebook.ts
@@ -1,4 +1,4 @@
-import { By, EditorView, VSBrowser, WebView } from 'vscode-extension-tester';
+import { By, EditorView, VSBrowser, WebElement, WebView } from 'vscode-extension-tester';
 
 import { OUTPUT_FRAME_SWITCH_TIMEOUT, OUTPUT_POLL_INTERVAL, OUTPUT_SELECTOR, WORKBENCH_TIMEOUT } from './constants';
 import { dismissAllNotifications } from './notifications';
@@ -57,12 +57,37 @@ export async function clickInterrupt(notebookFileName: string): Promise<void> {
     return clickNotebookToolbarButton(notebookFileName, 'Interrupt');
 }
 
+const CELL_STATUS_BAR_ITEM_SELECTOR = '.cell-statusbar-container .cell-status-item';
+
 /**
- * Clicks the notebook cell status bar item whose text contains `label`. Cell chrome lives in the
- * main window DOM (not the output iframe), so this switches out of the webview first and matches on
- * `textContent` — Selenium's `getText()` is empty for items scrolled out of view.
+ * The cell status bar items whose text contains `label`, ordered top to bottom as the user sees them.
+ * Cell chrome lives in the main window DOM (not the output iframe), so callers switch out of the
+ * webview first. Matches on `textContent` — Selenium's `getText()` is empty for items scrolled out
+ * of view. Sorted by screen position rather than DOM order because VS Code's notebook list recycles
+ * rows, so DOM order need not follow cell order.
  */
-export async function clickCellStatusBarItem(label: string): Promise<void> {
+async function findCellStatusBarItems(label: string): Promise<WebElement[]> {
+    const driver = VSBrowser.instance.driver;
+    const matches: { item: WebElement; top: number }[] = [];
+
+    for (const item of await driver.findElements(By.css(CELL_STATUS_BAR_ITEM_SELECTOR))) {
+        const text = (await item.getAttribute('textContent')) ?? '';
+        if (!text.includes(label)) {
+            continue;
+        }
+
+        const { y } = await item.getRect();
+        matches.push({ item, top: y });
+    }
+
+    return matches.sort((a, b) => a.top - b.top).map((match) => match.item);
+}
+
+/**
+ * Clicks the notebook cell status bar item whose text contains `label`. When several cells show the
+ * same item, `occurrence` picks which one, counted top to bottom from 0.
+ */
+export async function clickCellStatusBarItem(label: string, occurrence = 0): Promise<void> {
     const driver = VSBrowser.instance.driver;
 
     await new WebView().switchBack().catch((error) => {
@@ -74,19 +99,15 @@ export async function clickCellStatusBarItem(label: string): Promise<void> {
     await driver.wait(
         async () => {
             try {
-                for (const item of await driver.findElements(By.css('.cell-statusbar-container .cell-status-item'))) {
-                    const text = (await item.getAttribute('textContent')) ?? '';
-                    if (!text.includes(label)) {
-                        continue;
-                    }
-
-                    await driver.executeScript('arguments[0].scrollIntoView({block: "center"})', item);
-                    await item.click();
-
-                    return true;
+                const item = (await findCellStatusBarItems(label))[occurrence];
+                if (!item) {
+                    return false;
                 }
 
-                return false;
+                await driver.executeScript('arguments[0].scrollIntoView({block: "center"})', item);
+                await item.click();
+
+                return true;
             } catch (error) {
                 console.warn('[deepnote-e2e] locate/click cell status bar item (retrying):', error);
 
@@ -94,7 +115,33 @@ export async function clickCellStatusBarItem(label: string): Promise<void> {
             }
         },
         WORKBENCH_TIMEOUT,
-        `notebook cell status bar item "${label}" did not appear or could not be clicked`
+        `notebook cell status bar item "${label}" (occurrence ${occurrence}) did not appear or could not be clicked`
+    );
+}
+
+/**
+ * Polls until at least `count` cell status bar items contain `label`, so a metadata edit can be
+ * asserted through the UI it re-renders. Switches out of the output webview first.
+ */
+export async function awaitCellStatusBarItems(label: string, count: number, timeout: number): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+
+    await new WebView().switchBack().catch((error) => {
+        console.warn('[deepnote-e2e] switch back before reading cell status bar items:', error);
+    });
+
+    await driver.wait(
+        async () => {
+            try {
+                return (await findCellStatusBarItems(label)).length >= count;
+            } catch (error) {
+                console.warn('[deepnote-e2e] read cell status bar items (retrying):', error);
+
+                return false;
+            }
+        },
+        timeout,
+        `expected ${count} notebook cell status bar item(s) containing "${label}"`
     );
 }
 

--- a/test/e2e/suite/execution/sqlQueryChaining.e2e.test.ts
+++ b/test/e2e/suite/execution/sqlQueryChaining.e2e.test.ts
@@ -1,0 +1,106 @@
+/**
+ * ExTester E2E for SQL query chaining: a `.deepnote` with two DuckDB (DataFrame SQL) blocks where the second
+ * selects from the first block's variable. The test flips the first block to "Query preview" through the
+ * new cell status bar item, runs both blocks and asserts the chained block renders its result.
+ *
+ * The count is the tell: a query preview only materializes 100 rows, so `chained_rows_1234` can only render
+ * when the toolkit inlined the first block's full query as a CTE instead of reading the preview DataFrame.
+ */
+
+import { expect } from 'chai';
+import { EditorView, InputBox, VSBrowser, WebView } from 'vscode-extension-tester';
+
+import {
+    FIRST_RUN_OUTPUT_TIMEOUT,
+    QUICK_PICK_TIMEOUT,
+    SUITE_TIMEOUT,
+    WORKBENCH_TIMEOUT,
+    awaitCellStatusBarItems,
+    clickCellStatusBarItem,
+    copyFixtureToTempDir,
+    createEnvironment,
+    openFolderViaDialog,
+    openWorkspaceFile,
+    runOnceAndAwaitOutput,
+    selectEnvironmentForNotebook
+} from '../../helpers';
+
+const NOTEBOOK_FILE_NAME = 'sql-query-chaining.deepnote';
+
+// Status bar texts from `SqlReturnVariableType` in `src/platform/common/utils/localize.ts`.
+const DATAFRAME_STATUS_BAR_TEXT = 'Return: DataFrame';
+const QUERY_PREVIEW_STATUS_BAR_TEXT = 'Return: Query preview';
+const QUERY_PREVIEW_PICK_LABEL = 'Query preview';
+
+// `SELECT 'chained_rows_' || COUNT(*) ... FROM source_rows` over the 1234-row source query in the fixture.
+const EXPECTED_OUTPUT = 'chained_rows_1234';
+
+describe('Deepnote E2E — chain SQL blocks through a query preview', function () {
+    this.timeout(SUITE_TIMEOUT);
+
+    const environmentName = 'E2E SQL Chaining Env';
+
+    let cleanupTempDir: (() => void) | undefined;
+
+    before(async function () {
+        // Work on a throwaway copy so execution-dirtied notebook state never touches the source tree.
+        const { cleanup, tempDir } = copyFixtureToTempDir(NOTEBOOK_FILE_NAME);
+        cleanupTempDir = cleanup;
+
+        await VSBrowser.instance.waitForWorkbench(WORKBENCH_TIMEOUT);
+
+        // Open the folder as the workspace FIRST (the serializer's snapshot read blocks headlessly without one).
+        await openFolderViaDialog(tempDir);
+        await VSBrowser.instance.waitForWorkbench(WORKBENCH_TIMEOUT);
+
+        await openWorkspaceFile(NOTEBOOK_FILE_NAME);
+
+        // A single-notebook file resolves to its default notebook.
+        await VSBrowser.instance.driver.wait(
+            async () => (await new EditorView().getOpenEditorTitles()).some((t) => t.includes(NOTEBOOK_FILE_NAME)),
+            WORKBENCH_TIMEOUT,
+            'Deepnote notebook editor did not open'
+        );
+    });
+
+    after(async function () {
+        // Defensive cleanup: never leave the driver stuck inside a webview frame, and close tabs.
+        await new WebView().switchBack().catch((error) => {
+            console.warn('[deepnote-e2e] switch back from webview during cleanup:', error);
+        });
+        await new EditorView().closeAllEditors().catch((error) => {
+            console.warn('[deepnote-e2e] close all editors during cleanup:', error);
+        });
+
+        try {
+            cleanupTempDir?.();
+        } catch (error) {
+            console.warn('[deepnote-e2e] remove temp workspace dir during cleanup:', error);
+        }
+    });
+
+    it('switches the first block to Query preview from the status bar, then the second block queries it', async function () {
+        // Both SQL blocks start as DataFrame; the status bar renders one item per block.
+        await awaitCellStatusBarItems(DATAFRAME_STATUS_BAR_TEXT, 2, WORKBENCH_TIMEOUT);
+
+        // The status bar item on the FIRST block opens the return type picker.
+        await clickCellStatusBarItem(DATAFRAME_STATUS_BAR_TEXT, 0);
+        const picker = await InputBox.create(QUICK_PICK_TIMEOUT);
+        await picker.selectQuickPick(QUERY_PREVIEW_PICK_LABEL);
+
+        // The metadata edit re-renders the item; the second block keeps its DataFrame item.
+        await awaitCellStatusBarItems(QUERY_PREVIEW_STATUS_BAR_TEXT, 1, WORKBENCH_TIMEOUT);
+        await awaitCellStatusBarItems(DATAFRAME_STATUS_BAR_TEXT, 1, WORKBENCH_TIMEOUT);
+
+        await createEnvironment(environmentName);
+        await selectEnvironmentForNotebook(environmentName, NOTEBOOK_FILE_NAME);
+
+        // "Run All" executes the preview block first, then the block that chains onto its variable.
+        const renderedOutput = await runOnceAndAwaitOutput(
+            NOTEBOOK_FILE_NAME,
+            EXPECTED_OUTPUT,
+            FIRST_RUN_OUTPUT_TIMEOUT
+        );
+        expect(renderedOutput).to.contain(EXPECTED_OUTPUT);
+    });
+});


### PR DESCRIPTION
## Summary

Adds the one piece of SQL query chaining that was missing in the extension: a way to choose what a SQL block returns. Every SQL cell now shows a `Return: DataFrame` / `Return: Query preview` status bar item next to the integration and variable items; clicking it (or running **Deepnote: Set SQL Block Return Type** from the palette) opens a QuickPick that writes `deepnote_return_variable_type` into the cell metadata, which the existing serializer persists to the `.deepnote` file.

Closes #219

## What the user sees

- A third status bar item on SQL cells: `Return: DataFrame` (the default) or `Return: Query preview`.
- Its tooltip explains the difference: DataFrame materializes the result; Query preview keeps a lazy reference (with a 100-row preview) that later SQL blocks can select from, so they are chained into a single query.
- Clicking it opens a two-item QuickPick (`DataFrame` / `Query preview`, current one marked) and switches the block.
- `Deepnote: Set SQL Block Return Type` in the command palette, only when a Deepnote notebook is active; it acts on the selected cell.

## How it works

The backend already supported chaining end to end; only the UI was missing:

- `deepnote-toolkit` returns a `DeepnoteQueryPreview` when `return_variable_type='query_preview'` and un-chains references to such variables into CTEs (`sql/sql_query_chaining.py`, `sql/query_preview.py`), including for the DuckDB / DataFrame SQL integration.
- `@deepnote/blocks` `createPythonCode` already emits `return_variable_type` from `deepnote_return_variable_type`, and `deepnoteSchemas.ts` already validates the `'dataframe' | 'query_preview'` enum. The federated-auth code generator honoured it too.
- New SQL blocks are still created as `dataframe`; nothing changes for existing notebooks.

Changes:

- `src/notebooks/deepnote/sqlCellStatusBarProvider.ts`: new status bar item, `deepnote.setSqlReturnVariableType` command, QuickPick + `WorkspaceEdit` on the cell metadata, `switch_sql_return_variable_type` telemetry. The duplicated "fall back to the active cell" logic of the two existing commands moved into one `resolveTargetCell` helper shared by all three.
- `src/platform/common/utils/localize.ts`: `SqlReturnVariableType` strings.
- `src/platform/analytics/types.ts`: the new telemetry event.
- `package.json` / `package.nls.json`: command contribution with `enablement: notebookType == 'deepnote'` and a matching `commandPalette` `when`.
- No changes to `serviceRegistry.node.ts`, `src/kernels/deepnote/`, `src/platform/interpreter/` or `vscodeNotebookController.ts` (kept clear of #376); the existing provider registration is reused.

## Testing

Unit tests (`sqlCellStatusBarProvider.unit.test.ts`): the new item (default, `query_preview`, unknown value fallback), command registration, palette fallback to the active cell, and the handler (items offered, switching each way with telemetry, dismiss, no-op re-pick, failed edit).

E2E (`test/e2e/suite/execution/sqlQueryChaining.e2e.test.ts`, new fixture `sql-query-chaining.deepnote`): two DuckDB SQL blocks, the second selects from the first block's variable. The test flips the first block to Query preview via the status bar item, checks the item re-renders, runs both, and asserts the second renders `chained_rows_1234`. The 1234-row source with a 100-row preview means that value can only render when the toolkit inlined the first block's query as a CTE rather than reading the preview DataFrame. Two small helpers were added to `test/e2e/helpers/notebook.ts` (`clickCellStatusBarItem` gained an `occurrence` argument; `awaitCellStatusBarItems` is new).

**The E2E test was not run locally** (the ExTester VS Code download / venv harness is not set up on this machine); it compiles (`npm run compile-e2e`) and relies on CI's `execution` shard. As a sanity check of the assertion itself, the same two queries were run against `deepnote-toolkit` 2.5.1 with the DuckDB connection directly in Python: the preview came back as a 100-row `DeepnoteQueryPreview` and the chained query returned `chained_rows_1234`.

Gates run locally (Node 22.21.1):

- `npm run compile-tsc && npm test` — pass
- `npm run typecheck` — pass
- `npm run lint` — pass (pre-existing warnings only)
- `npm run format` — pass
- `npm run spell-check` — pass
- `npm run compile-e2e` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deepnote SQL blocks can now return either a DataFrame or a query preview.
  - Added a command-palette action to change the SQL return type.
  - The selected return type appears in the SQL cell status bar and is saved for future use.
  - Added options to reveal the Deepnote Explorer and restart the kernel from notebook controls.
- **Bug Fixes**
  - Improved SQL command handling when selecting the active cell.
  - Deepnote block-creation actions are now limited to Deepnote notebooks.
- **Tests**
  - Added coverage for return-type selection, persistence, cancellation, and SQL query chaining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->