### PR TITLE
feat(integrations): add an "Add Existing Integration" picker to reuse integrations across projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,12 @@
                 "icon": "$(plug)"
             },
             {
+                "command": "deepnote.addExistingIntegration",
+                "title": "%deepnote.commands.addExistingIntegration.title%",
+                "category": "Deepnote",
+                "icon": "$(link)"
+            },
+            {
                 "command": "deepnote.authenticateIntegration",
                 "title": "%deepnote.commands.authenticateIntegration.title%",
                 "category": "Deepnote"

--- a/package.nls.json
+++ b/package.nls.json
@@ -256,6 +256,7 @@
     "deepnote.commands.enableSnapshots.title": "Enable Snapshots",
     "deepnote.commands.disableSnapshots.title": "Disable Snapshots",
     "deepnote.commands.manageIntegrations.title": "Manage Integrations",
+    "deepnote.commands.addExistingIntegration.title": "Add Existing Integration",
     "deepnote.commands.authenticateIntegration.title": "Authenticate Integration",
     "deepnote.commands.newProject.title": "New Project",
     "deepnote.commands.importNotebook.title": "Import Notebook",

--- a/specs/INTEGRATIONS_CREDENTIALS.md
+++ b/specs/INTEGRATIONS_CREDENTIALS.md
@@ -433,6 +433,20 @@ Orchestrates the integration management UI and commands.
 3. Manager opens webview with integration list
 4. Optionally pre-selects a specific integration for configuration
 
+**Add Existing Integration** (`deepnote.addExistingIntegration`, also the "Add Existing Integration" button in the
+webview, implemented in `existingIntegrationPicker.ts`):
+
+1. Scans every `.deepnote` file in the workspace folders (snapshots excluded) and collects the roster entries of
+   _other_ projects whose id has a config in SecretStorage; ids already on the active project's roster are skipped,
+   as are file-only (`.deepnote.env.yaml`) integrations, which already apply workspace-wide.
+2. Shows a QuickPick (name, type, "Used in: <projects>"). An id whose roster type disagrees with the stored config's
+   type is dropped with a warning rather than offered.
+3. On selection, appends `{ id, name, type }` to the active project's roster via `persistProjectIntegrations`.
+   Nothing is copied in SecretStorage: configs (and federated refresh tokens) are keyed by integration id alone, and
+   the roster entry is what scopes an integration to a project, so the linked project resolves the same credentials.
+4. Re-runs the integration env refresh in the project's running kernels and re-shows the panel, since no storage
+   change event fires for a roster-only edit.
+
 #### 4. **Integration Webview** (`integrationWebview.ts`)
 
 Provides the webview-based UI for managing integration credentials.

--- a/src/messageTypes.ts
+++ b/src/messageTypes.ts
@@ -186,6 +186,7 @@ export type LocalizedMessages = {
     integrationsCancel: string;
     integrationsSave: string;
     integrationsAddNewIntegration: string;
+    integrationsAddExistingIntegration: string;
     integrationsDatabase: string;
     integrationsDataWarehousesLakes: string;
     integrationsDatabases: string;

--- a/src/notebooks/deepnote/integrations/existingIntegrationPicker.ts
+++ b/src/notebooks/deepnote/integrations/existingIntegrationPicker.ts
@@ -1,3 +1,4 @@
+import type { DeepnoteFile } from '@deepnote/blocks';
 import { RelativePattern, Uri, workspace } from 'vscode';
 
 import * as localize from '../../../platform/common/utils/localize';
@@ -38,6 +39,9 @@ export function integrationTypeLabel(type: ConfigurableDatabaseIntegrationType):
     return INTEGRATION_TYPE_LABELS[type] ?? type;
 }
 
+/** A roster entry exactly as the `.deepnote` file records it; `type` is not narrowed to the types this build knows. */
+export type RawProjectIntegration = NonNullable<DeepnoteFile['project']['integrations']>[number];
+
 /**
  * A SecretStorage integration declared by at least one *other* project in the workspace, so it can be linked into
  * the current project without re-entering credentials.
@@ -71,8 +75,11 @@ export interface CollectReusableIntegrationsResult {
 
 export interface AttachExistingIntegrationParams {
     activeFileUri: Uri;
-    /** The current project's roster as cached by the notebook manager; the new entry is appended to it. */
-    currentIntegrations: readonly ProjectIntegration[];
+    /**
+     * The current project's roster exactly as cached by the notebook manager. Every entry passes through to the
+     * write verbatim (including `pandas-dataframe` and any type this build does not know), so nothing is pruned.
+     */
+    currentIntegrations: readonly RawProjectIntegration[];
     integration: ReusableIntegration;
     notebookManager: IDeepnoteNotebookManager;
     projectId: string;
@@ -195,10 +202,13 @@ export async function collectReusableIntegrations(
 export function attachExistingIntegration(params: AttachExistingIntegrationParams): Promise<PersistIntegrationsResult> {
     const { activeFileUri, currentIntegrations, integration, notebookManager, projectId } = params;
 
-    const integrations: ProjectIntegration[] = [
+    const linked: ProjectIntegration = { id: integration.id, name: integration.name, type: integration.type };
+    // Cast rather than narrow: validating the existing entries would silently drop any type this build does not
+    // know about (`pandas-dataframe` included), which is pruning by another name.
+    const integrations = [
         ...currentIntegrations.filter((entry) => entry.id !== integration.id),
-        { id: integration.id, name: integration.name, type: integration.type }
-    ];
+        linked
+    ] as ProjectIntegration[];
 
     return persistProjectIntegrations({ activeFileUri, integrations, notebookManager, projectId });
 }

--- a/src/notebooks/deepnote/integrations/existingIntegrationPicker.ts
+++ b/src/notebooks/deepnote/integrations/existingIntegrationPicker.ts
@@ -1,0 +1,204 @@
+import { RelativePattern, Uri, workspace } from 'vscode';
+
+import * as localize from '../../../platform/common/utils/localize';
+import { readDeepnoteProjectFile } from '../../../platform/deepnote/deepnoteProjectFileReader';
+import { logger } from '../../../platform/logging';
+import {
+    ConfigurableDatabaseIntegrationType,
+    isConfigurableDatabaseIntegrationType
+} from '../../../platform/notebooks/deepnote/integrationTypes';
+import { IDeepnoteNotebookManager, ProjectIntegration } from '../../types';
+import { isSnapshotFile } from '../snapshots/snapshotFiles';
+import { PersistIntegrationsResult, persistProjectIntegrations } from './projectIntegrationsWriter';
+import { IIntegrationStorage } from './types';
+
+/** Human-readable type labels for the picker; mirrors `integrationTypeLabels` in the webview bundle. */
+const INTEGRATION_TYPE_LABELS: Record<ConfigurableDatabaseIntegrationType, string> = {
+    alloydb: localize.Integrations.alloyDBTypeLabel,
+    athena: localize.Integrations.athenaTypeLabel,
+    'big-query': localize.Integrations.bigQueryTypeLabel,
+    clickhouse: localize.Integrations.clickHouseTypeLabel,
+    'cloud-sql': localize.Integrations.cloudSqlTypeLabel,
+    databricks: localize.Integrations.databricksTypeLabel,
+    dremio: localize.Integrations.dremioTypeLabel,
+    mariadb: localize.Integrations.mariaDBTypeLabel,
+    materialize: localize.Integrations.materializeTypeLabel,
+    mindsdb: localize.Integrations.mindsDBTypeLabel,
+    mongodb: localize.Integrations.mongoDBTypeLabel,
+    mysql: localize.Integrations.mySQLTypeLabel,
+    pgsql: localize.Integrations.postgresTypeLabel,
+    redshift: localize.Integrations.redshiftTypeLabel,
+    snowflake: localize.Integrations.snowflakeTypeLabel,
+    spanner: localize.Integrations.spannerTypeLabel,
+    'sql-server': localize.Integrations.sqlServerTypeLabel,
+    trino: localize.Integrations.trinoTypeLabel
+};
+
+export function integrationTypeLabel(type: ConfigurableDatabaseIntegrationType): string {
+    return INTEGRATION_TYPE_LABELS[type] ?? type;
+}
+
+/**
+ * A SecretStorage integration declared by at least one *other* project in the workspace, so it can be linked into
+ * the current project without re-entering credentials.
+ */
+export interface ReusableIntegration {
+    id: string;
+    /** Name from the stored config — the same source the panel writes to the roster on save. */
+    name: string;
+    /** Display names of the other projects whose roster declares this integration; deduped and sorted. */
+    projectNames: string[];
+    type: ConfigurableDatabaseIntegrationType;
+}
+
+export interface CollectReusableIntegrationsParams {
+    /** Integration ids already on the current project's roster; never offered again. */
+    excludeIntegrationIds: ReadonlySet<string>;
+    integrationStorage: IIntegrationStorage;
+    /** The project being extended; its own `.deepnote` files are skipped. */
+    projectId: string;
+}
+
+export interface CollectReusableIntegrationsResult {
+    /**
+     * Ids skipped because a project's roster declares the integration with a type that differs from the stored
+     * configuration. Linking such an entry would put a roster type on this project that the credentials cannot
+     * back, so the caller warns instead.
+     */
+    conflictingIds: string[];
+    integrations: ReusableIntegration[];
+}
+
+export interface AttachExistingIntegrationParams {
+    activeFileUri: Uri;
+    /** The current project's roster as cached by the notebook manager; the new entry is appended to it. */
+    currentIntegrations: readonly ProjectIntegration[];
+    integration: ReusableIntegration;
+    notebookManager: IDeepnoteNotebookManager;
+    projectId: string;
+}
+
+/**
+ * Scans every `.deepnote` file in the open workspace folders and collects the SecretStorage integrations other
+ * projects declare.
+ *
+ * Storage design: `IntegrationStorage` keys configs by integration id alone (there is no per-project namespace),
+ * and both the env-var provider and the detector resolve credentials from the project roster
+ * (`project.integrations[].id`). The roster entry is therefore the only thing that "attaches" an integration to a
+ * project, and reusing one is a pure link: no config is copied. Federated (`google-oauth`) integrations are
+ * included for the same reason — `FederatedAuthTokenStorage` is also keyed by integration id, and the per-cell
+ * code generator resolves the config through the roster of the notebook being run.
+ *
+ * Integrations configured only in `.deepnote.env.yaml` (no stored config) are not offered: that file already
+ * applies to every project under it, and the panel cannot write that layer.
+ */
+export async function collectReusableIntegrations(
+    params: CollectReusableIntegrationsParams
+): Promise<CollectReusableIntegrationsResult> {
+    const { excludeIntegrationIds, integrationStorage, projectId } = params;
+
+    const candidates = new Map<string, ReusableIntegration & { projectNameSet: Set<string> }>();
+    const conflictingIds = new Set<string>();
+    const visited = new Set<string>();
+
+    for (const workspaceFolder of workspace.workspaceFolders || []) {
+        let files: Uri[];
+
+        try {
+            files = await workspace.findFiles(new RelativePattern(workspaceFolder, '**/*.deepnote'));
+        } catch (error) {
+            logger.error('collectReusableIntegrations: failed to enumerate .deepnote files', error);
+
+            continue;
+        }
+
+        for (const fileUri of files) {
+            const key = fileUri.toString();
+
+            if (visited.has(key) || isSnapshotFile(fileUri)) {
+                continue;
+            }
+
+            visited.add(key);
+
+            // Per-file try/catch: one unreadable file must not hide every other project's integrations.
+            try {
+                const projectData = await readDeepnoteProjectFile(fileUri);
+
+                if (!projectData?.project || projectData.project.id === projectId) {
+                    continue;
+                }
+
+                const projectName = projectData.project.name || projectData.project.id;
+
+                for (const entry of projectData.project.integrations ?? []) {
+                    if (excludeIntegrationIds.has(entry.id) || !isConfigurableDatabaseIntegrationType(entry.type)) {
+                        continue;
+                    }
+
+                    const storedConfig = await integrationStorage.getIntegrationConfig(entry.id);
+
+                    if (!storedConfig) {
+                        // File-only or never-configured: there are no credentials in SecretStorage to reuse.
+                        continue;
+                    }
+
+                    if (storedConfig.type !== entry.type) {
+                        logger.warn(
+                            `collectReusableIntegrations: ${entry.id} is declared as ${entry.type} in ${fileUri.path} but stored as ${storedConfig.type}; skipping`
+                        );
+                        conflictingIds.add(entry.id);
+
+                        continue;
+                    }
+
+                    const existing = candidates.get(entry.id);
+
+                    if (existing) {
+                        existing.projectNameSet.add(projectName);
+                    } else {
+                        candidates.set(entry.id, {
+                            id: entry.id,
+                            name: storedConfig.name || entry.name || entry.id,
+                            projectNameSet: new Set([projectName]),
+                            projectNames: [],
+                            type: storedConfig.type
+                        });
+                    }
+                }
+            } catch (error) {
+                logger.error(`collectReusableIntegrations: failed to read ${fileUri.path}`, error);
+            }
+        }
+    }
+
+    // A conflict in any project disqualifies the id everywhere: the stored config is the single shared truth.
+    for (const id of conflictingIds) {
+        candidates.delete(id);
+    }
+
+    const integrations = Array.from(candidates.values())
+        .map(({ projectNameSet, ...candidate }) => ({
+            ...candidate,
+            projectNames: Array.from(projectNameSet).sort((a, b) => a.localeCompare(b))
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+
+    return { conflictingIds: Array.from(conflictingIds).sort(), integrations };
+}
+
+/**
+ * Links `integration` into the project's roster and persists it through the same writer the panel uses, so the
+ * cache, the active file and every sibling `.deepnote` file of the project are updated together. Idempotent for an
+ * id already on the roster (the entry is replaced, not duplicated).
+ */
+export function attachExistingIntegration(params: AttachExistingIntegrationParams): Promise<PersistIntegrationsResult> {
+    const { activeFileUri, currentIntegrations, integration, notebookManager, projectId } = params;
+
+    const integrations: ProjectIntegration[] = [
+        ...currentIntegrations.filter((entry) => entry.id !== integration.id),
+        { id: integration.id, name: integration.name, type: integration.type }
+    ];
+
+    return persistProjectIntegrations({ activeFileUri, integrations, notebookManager, projectId });
+}

--- a/src/notebooks/deepnote/integrations/existingIntegrationPicker.unit.test.ts
+++ b/src/notebooks/deepnote/integrations/existingIntegrationPicker.unit.test.ts
@@ -1,0 +1,340 @@
+import { deserializeDeepnoteFile, serializeDeepnoteFile, type DeepnoteFile } from '@deepnote/blocks';
+import { assert } from 'chai';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { Uri, workspace } from 'vscode';
+
+import { ConfigurableDatabaseIntegrationConfig } from '../../../platform/notebooks/deepnote/integrationTypes';
+import { mockedVSCodeNamespaces, resetVSCodeMocks } from '../../../test/vscode-mock';
+import { IDeepnoteNotebookManager, ProjectIntegration } from '../../types';
+import { createDeepnoteFile, createDeepnoteProject, createWorkspaceFolder } from '../deepnoteTestHelpers';
+import {
+    attachExistingIntegration,
+    collectReusableIntegrations,
+    integrationTypeLabel,
+    ReusableIntegration
+} from './existingIntegrationPicker';
+import { buildGoogleOauthIntegration, buildPostgresIntegration } from './federatedAuth/federatedAuthTestHelpers';
+import { IIntegrationStorage } from './types';
+
+const CURRENT_PROJECT_ID = 'project-current';
+
+interface OnDiskProject {
+    uri: Uri;
+    projectId: string;
+    projectName?: string;
+    integrations?: Array<{ id: string; name: string; type: string }>;
+}
+
+function projectFile(project: OnDiskProject): DeepnoteFile {
+    return createDeepnoteFile({
+        project: createDeepnoteProject({
+            id: project.projectId,
+            name: project.projectName ?? project.projectId,
+            // The roster type is a plain string on disk; the cast keeps the fixture free to declare unknown types.
+            integrations: project.integrations as ProjectIntegration[] | undefined
+        })
+    });
+}
+
+/** Stubs `workspace.findFiles` + `workspace.fs` over the given files; `unreadable` URIs reject on read. */
+function stubWorkspace(opts: { projects: OnDiskProject[]; unreadable?: Uri[]; hasWorkspaceFolder?: boolean }): {
+    writes: Map<string, DeepnoteFile>;
+} {
+    when(mockedVSCodeNamespaces.workspace.workspaceFolders).thenReturn(
+        opts.hasWorkspaceFolder === false ? undefined : [createWorkspaceFolder(Uri.file('/ws'))]
+    );
+
+    const discovered = [...opts.projects.map((project) => project.uri), ...(opts.unreadable ?? [])];
+    when(mockedVSCodeNamespaces.workspace.findFiles(anything())).thenReturn(Promise.resolve(discovered));
+    when(mockedVSCodeNamespaces.workspace.notebookDocuments).thenReturn([]);
+
+    const byPath = new Map(opts.projects.map((project) => [project.uri.fsPath, projectFile(project)] as const));
+    const writes = new Map<string, DeepnoteFile>();
+    const mockFs = mock<typeof workspace.fs>();
+
+    when(mockFs.readFile(anything())).thenCall((uri: Uri) => {
+        const file = byPath.get(uri.fsPath);
+
+        return file
+            ? Promise.resolve(new TextEncoder().encode(serializeDeepnoteFile(file)))
+            : Promise.reject(new Error(`no readFile stub for ${uri.fsPath}`));
+    });
+    when(mockFs.writeFile(anything(), anything())).thenCall((uri: Uri, bytes: Uint8Array) => {
+        writes.set(uri.fsPath, deserializeDeepnoteFile(new TextDecoder().decode(bytes)));
+
+        return Promise.resolve();
+    });
+    when(mockedVSCodeNamespaces.workspace.fs).thenReturn(instance(mockFs));
+
+    return { writes };
+}
+
+function stubStorage(configs: ConfigurableDatabaseIntegrationConfig[]): IIntegrationStorage {
+    const byId = new Map(configs.map((config) => [config.id, config] as const));
+    const storage = mock<IIntegrationStorage>();
+
+    when(storage.getIntegrationConfig(anything())).thenCall((id: string) => Promise.resolve(byId.get(id)));
+
+    return instance(storage);
+}
+
+suite('existingIntegrationPicker', () => {
+    setup(() => {
+        resetVSCodeMocks();
+    });
+
+    suite('collectReusableIntegrations', () => {
+        const pgConfig = buildPostgresIntegration({ id: 'pg-shared', name: 'Shared Postgres' });
+        const bqConfig = buildGoogleOauthIntegration({ id: 'bq-oauth', name: 'Team BigQuery' });
+
+        async function collect(
+            excludeIntegrationIds: string[] = [],
+            configs: ConfigurableDatabaseIntegrationConfig[] = [pgConfig, bqConfig]
+        ) {
+            return collectReusableIntegrations({
+                excludeIntegrationIds: new Set(excludeIntegrationIds),
+                integrationStorage: stubStorage(configs),
+                projectId: CURRENT_PROJECT_ID
+            });
+        }
+
+        test('lists integrations other projects declare, deduped by id with every using project named', async () => {
+            stubWorkspace({
+                projects: [
+                    {
+                        uri: Uri.file('/ws/a.deepnote'),
+                        projectId: 'project-a',
+                        projectName: 'Alpha',
+                        integrations: [{ id: 'pg-shared', name: 'Alpha Postgres', type: 'pgsql' }]
+                    },
+                    {
+                        uri: Uri.file('/ws/b.deepnote'),
+                        projectId: 'project-b',
+                        projectName: 'Beta',
+                        integrations: [
+                            { id: 'pg-shared', name: 'Beta Postgres', type: 'pgsql' },
+                            { id: 'bq-oauth', name: 'Team BigQuery', type: 'big-query' }
+                        ]
+                    },
+                    // A second notebook file of Beta must not list Beta twice.
+                    {
+                        uri: Uri.file('/ws/b-2.deepnote'),
+                        projectId: 'project-b',
+                        projectName: 'Beta',
+                        integrations: [{ id: 'pg-shared', name: 'Beta Postgres', type: 'pgsql' }]
+                    }
+                ]
+            });
+
+            const result = await collect();
+
+            const expected: ReusableIntegration[] = [
+                { id: 'pg-shared', name: 'Shared Postgres', projectNames: ['Alpha', 'Beta'], type: 'pgsql' },
+                { id: 'bq-oauth', name: 'Team BigQuery', projectNames: ['Beta'], type: 'big-query' }
+            ];
+            assert.deepStrictEqual(result, { conflictingIds: [], integrations: expected });
+        });
+
+        test('takes the name from the stored config, not from whichever roster was read first', async () => {
+            stubWorkspace({
+                projects: [
+                    {
+                        uri: Uri.file('/ws/a.deepnote'),
+                        projectId: 'project-a',
+                        integrations: [{ id: 'pg-shared', name: 'Stale roster name', type: 'pgsql' }]
+                    }
+                ]
+            });
+
+            const { integrations } = await collect();
+
+            assert.strictEqual(integrations[0].name, 'Shared Postgres');
+        });
+
+        test('excludes ids already on the current project roster and the current project files themselves', async () => {
+            stubWorkspace({
+                projects: [
+                    {
+                        uri: Uri.file('/ws/current.deepnote'),
+                        projectId: CURRENT_PROJECT_ID,
+                        integrations: [{ id: 'bq-oauth', name: 'Team BigQuery', type: 'big-query' }]
+                    },
+                    {
+                        uri: Uri.file('/ws/a.deepnote'),
+                        projectId: 'project-a',
+                        integrations: [
+                            { id: 'pg-shared', name: 'Shared Postgres', type: 'pgsql' },
+                            { id: 'bq-oauth', name: 'Team BigQuery', type: 'big-query' }
+                        ]
+                    }
+                ]
+            });
+
+            const { integrations } = await collect(['pg-shared']);
+
+            assert.deepStrictEqual(
+                integrations.map((integration) => integration.id),
+                ['bq-oauth'],
+                'pg-shared is already attached; bq-oauth is offered because project-a (not the current project) declares it'
+            );
+        });
+
+        test('skips roster entries with no stored config (file-only or never configured) and unsupported types', async () => {
+            stubWorkspace({
+                projects: [
+                    {
+                        uri: Uri.file('/ws/a.deepnote'),
+                        projectId: 'project-a',
+                        integrations: [
+                            { id: 'file-only', name: 'From env yaml', type: 'pgsql' },
+                            { id: 'duckdb', name: 'DuckDB', type: 'pandas-dataframe' },
+                            { id: 'pg-shared', name: 'Shared Postgres', type: 'pgsql' }
+                        ]
+                    }
+                ]
+            });
+
+            const { integrations } = await collect();
+
+            assert.deepStrictEqual(
+                integrations.map((integration) => integration.id),
+                ['pg-shared']
+            );
+        });
+
+        test('reports an id whose roster type disagrees with the stored config as conflicting and drops it everywhere', async () => {
+            stubWorkspace({
+                projects: [
+                    {
+                        uri: Uri.file('/ws/a.deepnote'),
+                        projectId: 'project-a',
+                        integrations: [{ id: 'pg-shared', name: 'Shared Postgres', type: 'pgsql' }]
+                    },
+                    {
+                        uri: Uri.file('/ws/b.deepnote'),
+                        projectId: 'project-b',
+                        // Same id, but declared as a different database than the credentials are for.
+                        integrations: [{ id: 'pg-shared', name: 'Not really Postgres', type: 'mysql' }]
+                    }
+                ]
+            });
+
+            const result = await collect();
+
+            assert.deepStrictEqual(result, { conflictingIds: ['pg-shared'], integrations: [] });
+        });
+
+        test('ignores snapshot files and keeps going past an unreadable file', async () => {
+            stubWorkspace({
+                projects: [
+                    {
+                        uri: Uri.file('/ws/snapshots/a_project-a_2024.snapshot.deepnote'),
+                        projectId: 'project-snapshot',
+                        integrations: [{ id: 'bq-oauth', name: 'Team BigQuery', type: 'big-query' }]
+                    },
+                    {
+                        uri: Uri.file('/ws/a.deepnote'),
+                        projectId: 'project-a',
+                        integrations: [{ id: 'pg-shared', name: 'Shared Postgres', type: 'pgsql' }]
+                    }
+                ],
+                unreadable: [Uri.file('/ws/broken.deepnote')]
+            });
+
+            const { integrations } = await collect();
+
+            assert.deepStrictEqual(
+                integrations.map((integration) => integration.id),
+                ['pg-shared']
+            );
+        });
+
+        test('returns nothing without an open workspace folder', async () => {
+            stubWorkspace({ projects: [], hasWorkspaceFolder: false });
+
+            const result = await collect();
+
+            assert.deepStrictEqual(result, { conflictingIds: [], integrations: [] });
+        });
+    });
+
+    suite('attachExistingIntegration', () => {
+        const activeUri = Uri.file('/ws/current.deepnote');
+        const shared: ReusableIntegration = {
+            id: 'pg-shared',
+            name: 'Shared Postgres',
+            projectNames: ['Alpha'],
+            type: 'pgsql'
+        };
+
+        let notebookManager: IDeepnoteNotebookManager;
+        let cacheUpdates: Array<{ projectId: string; integrations: ProjectIntegration[] }>;
+
+        setup(() => {
+            cacheUpdates = [];
+            const mockManager = mock<IDeepnoteNotebookManager>();
+            when(mockManager.updateProjectIntegrations(anything(), anything())).thenCall(
+                (projectId: string, integrations: ProjectIntegration[]) => {
+                    cacheUpdates.push({ projectId, integrations });
+
+                    return true;
+                }
+            );
+            notebookManager = instance(mockManager);
+        });
+
+        test('appends the linked entry to the roster in the cache and on disk, keeping existing entries', async () => {
+            const { writes } = stubWorkspace({
+                projects: [
+                    {
+                        uri: activeUri,
+                        projectId: CURRENT_PROJECT_ID,
+                        integrations: [{ id: 'bq-own', name: 'Own BigQuery', type: 'big-query' }]
+                    }
+                ]
+            });
+            const currentIntegrations: ProjectIntegration[] = [
+                { id: 'bq-own', name: 'Own BigQuery', type: 'big-query' }
+            ];
+
+            const result = await attachExistingIntegration({
+                activeFileUri: activeUri,
+                currentIntegrations,
+                integration: shared,
+                notebookManager,
+                projectId: CURRENT_PROJECT_ID
+            });
+
+            const expectedRoster: ProjectIntegration[] = [
+                { id: 'bq-own', name: 'Own BigQuery', type: 'big-query' },
+                { id: 'pg-shared', name: 'Shared Postgres', type: 'pgsql' }
+            ];
+            assert.deepStrictEqual(result, { activePersisted: true, siblingsFailed: 0 });
+            assert.deepStrictEqual(cacheUpdates, [{ projectId: CURRENT_PROJECT_ID, integrations: expectedRoster }]);
+            assert.deepStrictEqual(writes.get(activeUri.fsPath)?.project.integrations, expectedRoster);
+        });
+
+        test('replaces rather than duplicates an entry whose id is already on the roster', async () => {
+            const { writes } = stubWorkspace({
+                projects: [{ uri: activeUri, projectId: CURRENT_PROJECT_ID }]
+            });
+
+            await attachExistingIntegration({
+                activeFileUri: activeUri,
+                currentIntegrations: [{ id: 'pg-shared', name: 'Old name', type: 'pgsql' }],
+                integration: shared,
+                notebookManager,
+                projectId: CURRENT_PROJECT_ID
+            });
+
+            assert.deepStrictEqual(writes.get(activeUri.fsPath)?.project.integrations, [
+                { id: 'pg-shared', name: 'Shared Postgres', type: 'pgsql' }
+            ]);
+        });
+    });
+
+    test('integrationTypeLabel maps every configurable type to a display label', () => {
+        assert.strictEqual(integrationTypeLabel('pgsql'), 'PostgreSQL');
+        assert.strictEqual(integrationTypeLabel('big-query'), 'Google BigQuery');
+    });
+});

--- a/src/notebooks/deepnote/integrations/existingIntegrationPicker.unit.test.ts
+++ b/src/notebooks/deepnote/integrations/existingIntegrationPicker.unit.test.ts
@@ -11,6 +11,7 @@ import {
     attachExistingIntegration,
     collectReusableIntegrations,
     integrationTypeLabel,
+    RawProjectIntegration,
     ReusableIntegration
 } from './existingIntegrationPicker';
 import { buildGoogleOauthIntegration, buildPostgresIntegration } from './federatedAuth/federatedAuthTestHelpers';
@@ -310,6 +311,31 @@ suite('existingIntegrationPicker', () => {
                 { id: 'pg-shared', name: 'Shared Postgres', type: 'pgsql' }
             ];
             assert.deepStrictEqual(result, { activePersisted: true, siblingsFailed: 0 });
+            assert.deepStrictEqual(cacheUpdates, [{ projectId: CURRENT_PROJECT_ID, integrations: expectedRoster }]);
+            assert.deepStrictEqual(writes.get(activeUri.fsPath)?.project.integrations, expectedRoster);
+        });
+
+        test('passes roster entries of types it cannot manage (e.g. pandas-dataframe) through verbatim', async () => {
+            const { writes } = stubWorkspace({
+                projects: [{ uri: activeUri, projectId: CURRENT_PROJECT_ID }]
+            });
+            const currentIntegrations: RawProjectIntegration[] = [
+                { id: 'duckdb', name: 'DuckDB', type: 'pandas-dataframe' },
+                { id: 'future', name: 'Unknown to this build', type: 'some-future-type' }
+            ];
+
+            await attachExistingIntegration({
+                activeFileUri: activeUri,
+                currentIntegrations,
+                integration: shared,
+                notebookManager,
+                projectId: CURRENT_PROJECT_ID
+            });
+
+            const expectedRoster = [
+                ...currentIntegrations,
+                { id: 'pg-shared', name: 'Shared Postgres', type: 'pgsql' }
+            ];
             assert.deepStrictEqual(cacheUpdates, [{ projectId: CURRENT_PROJECT_ID, integrations: expectedRoster }]);
             assert.deepStrictEqual(writes.get(activeUri.fsPath)?.project.integrations, expectedRoster);
         });

--- a/src/notebooks/deepnote/integrations/integrationManager.ts
+++ b/src/notebooks/deepnote/integrations/integrationManager.ts
@@ -6,7 +6,6 @@ import { IExtensionContext } from '../../../platform/common/types';
 import { Commands } from '../../../platform/common/constants';
 import * as localize from '../../../platform/common/utils/localize';
 import { logger } from '../../../platform/logging';
-import { isConfigurableDatabaseIntegrationType } from '../../../platform/notebooks/deepnote/integrationTypes';
 import {
     IIntegrationDetector,
     IIntegrationEnvLiveRefresher,
@@ -14,12 +13,13 @@ import {
     IIntegrationStorage,
     IIntegrationWebviewProvider
 } from './types';
-import { IDeepnoteNotebookManager, ProjectIntegration } from '../../types';
+import { IDeepnoteNotebookManager } from '../../types';
 import { DatabaseIntegrationType, databaseIntegrationTypes } from '@deepnote/database-integrations';
 import {
     attachExistingIntegration,
     collectReusableIntegrations,
     integrationTypeLabel,
+    RawProjectIntegration,
     ReusableIntegration
 } from './existingIntegrationPicker';
 
@@ -207,18 +207,15 @@ export class IntegrationManager implements IIntegrationManager {
         return uri ? String(uri) : undefined;
     }
 
-    /** The project's roster as the notebook manager caches it, narrowed to the types the panel can manage. */
-    private getCachedRoster(projectId: string, notebookId: string): ProjectIntegration[] {
+    /**
+     * The project's roster exactly as the notebook manager caches it. Entries are never filtered here: this array
+     * is what `attachExistingIntegration` persists, so narrowing it (e.g. dropping `pandas-dataframe`) would
+     * rewrite the project's integrations rather than add to them. Callers derive their own exclusion set from it.
+     */
+    private getCachedRoster(projectId: string, notebookId: string): RawProjectIntegration[] {
         const project = this.notebookManager.getProjectForNotebook(projectId, notebookId);
-        const roster: ProjectIntegration[] = [];
 
-        for (const entry of project?.project.integrations ?? []) {
-            if (isConfigurableDatabaseIntegrationType(entry.type)) {
-                roster.push({ id: entry.id, name: entry.name, type: entry.type });
-            }
-        }
-
-        return roster;
+        return [...(project?.project.integrations ?? [])];
     }
 
     /** Re-applies integration env in the project's running kernels and re-renders the panel with the new roster. */

--- a/src/notebooks/deepnote/integrations/integrationManager.ts
+++ b/src/notebooks/deepnote/integrations/integrationManager.ts
@@ -1,12 +1,31 @@
-import { inject, injectable } from 'inversify';
-import { commands, l10n, NotebookDocument, window, workspace } from 'vscode';
+import { inject, injectable, optional } from 'inversify';
+import { commands, l10n, NotebookDocument, QuickPickItem, window, workspace } from 'vscode';
 
+import { CommandOutcome, ITelemetryService } from '../../../platform/analytics/types';
 import { IExtensionContext } from '../../../platform/common/types';
 import { Commands } from '../../../platform/common/constants';
+import * as localize from '../../../platform/common/utils/localize';
 import { logger } from '../../../platform/logging';
-import { IIntegrationDetector, IIntegrationManager, IIntegrationStorage, IIntegrationWebviewProvider } from './types';
-import { IDeepnoteNotebookManager } from '../../types';
+import { isConfigurableDatabaseIntegrationType } from '../../../platform/notebooks/deepnote/integrationTypes';
+import {
+    IIntegrationDetector,
+    IIntegrationEnvLiveRefresher,
+    IIntegrationManager,
+    IIntegrationStorage,
+    IIntegrationWebviewProvider
+} from './types';
+import { IDeepnoteNotebookManager, ProjectIntegration } from '../../types';
 import { DatabaseIntegrationType, databaseIntegrationTypes } from '@deepnote/database-integrations';
+import {
+    attachExistingIntegration,
+    collectReusableIntegrations,
+    integrationTypeLabel,
+    ReusableIntegration
+} from './existingIntegrationPicker';
+
+interface ReusableIntegrationQuickPickItem extends QuickPickItem {
+    integration: ReusableIntegration;
+}
 
 /**
  * Manages integration UI and commands for Deepnote notebooks
@@ -18,7 +37,12 @@ export class IntegrationManager implements IIntegrationManager {
         @inject(IIntegrationDetector) private readonly integrationDetector: IIntegrationDetector,
         @inject(IIntegrationStorage) private readonly integrationStorage: IIntegrationStorage,
         @inject(IIntegrationWebviewProvider) private readonly webviewProvider: IIntegrationWebviewProvider,
-        @inject(IDeepnoteNotebookManager) private readonly notebookManager: IDeepnoteNotebookManager
+        @inject(IDeepnoteNotebookManager) private readonly notebookManager: IDeepnoteNotebookManager,
+        @inject(ITelemetryService) private readonly analytics: ITelemetryService,
+        // Node-only service: the web extension has no kernels to refresh.
+        @inject(IIntegrationEnvLiveRefresher)
+        @optional()
+        private readonly liveRefresher?: IIntegrationEnvLiveRefresher
     ) {}
 
     public activate(): void {
@@ -48,6 +72,127 @@ export class IntegrationManager implements IIntegrationManager {
                 return this.showIntegrationsUI(integrationId, notebookUri);
             })
         );
+
+        // Links an integration another project in the workspace already configured into the active project.
+        // Takes the same argument shapes as ManageIntegrations so the panel and menus can pass a notebook URI.
+        this.extensionContext.subscriptions.push(
+            commands.registerCommand(Commands.AddExistingIntegration, (...args: unknown[]) => {
+                let notebookUri: string | undefined;
+
+                for (const arg of args) {
+                    notebookUri ??= this.extractNotebookUri(arg);
+                }
+
+                return this.addExistingIntegration(notebookUri);
+            })
+        );
+    }
+
+    /**
+     * Offers the SecretStorage integrations other projects in the workspace declare, and links the chosen one into
+     * the active project's roster. Public so tests can drive it without `commands.executeCommand`.
+     *
+     * Credentials are not copied: `IntegrationStorage` is keyed by integration id alone, so the roster entry is all
+     * that scopes an integration to a project (see `collectReusableIntegrations`).
+     */
+    public async addExistingIntegration(notebookUri?: string): Promise<CommandOutcome> {
+        const activeNotebook = this.resolveDeepnoteNotebook(notebookUri);
+
+        if (!activeNotebook) {
+            void window.showErrorMessage(l10n.t('No active Deepnote notebook'));
+
+            return 'failed';
+        }
+
+        const projectId = activeNotebook.metadata?.deepnoteProjectId;
+        const notebookId = activeNotebook.metadata?.deepnoteNotebookId;
+
+        if (!projectId || !notebookId) {
+            void window.showErrorMessage(l10n.t('Cannot determine project or notebook ID'));
+
+            return 'failed';
+        }
+
+        const currentIntegrations = this.getCachedRoster(projectId, notebookId);
+        const { conflictingIds, integrations } = await collectReusableIntegrations({
+            excludeIntegrationIds: new Set(currentIntegrations.map((entry) => entry.id)),
+            integrationStorage: this.integrationStorage,
+            projectId
+        });
+
+        if (conflictingIds.length > 0) {
+            void window.showWarningMessage(
+                localize.Integrations.addExistingIntegrationConflictsSkipped(conflictingIds.length)
+            );
+        }
+
+        if (integrations.length === 0) {
+            void window.showInformationMessage(localize.Integrations.addExistingIntegrationNoneAvailable);
+
+            return 'completed';
+        }
+
+        const items: ReusableIntegrationQuickPickItem[] = integrations.map((integration) => ({
+            description: integrationTypeLabel(integration.type),
+            detail: localize.Integrations.addExistingIntegrationUsedIn(integration.projectNames.join(', ')),
+            integration,
+            label: integration.name
+        }));
+
+        const picked = await window.showQuickPick(items, {
+            matchOnDescription: true,
+            matchOnDetail: true,
+            placeHolder: localize.Integrations.addExistingIntegrationPlaceholder
+        });
+
+        if (!picked) {
+            return 'cancelled';
+        }
+
+        const { integration } = picked;
+        let outcome: CommandOutcome = 'failed';
+
+        try {
+            const { activePersisted, siblingsFailed } = await attachExistingIntegration({
+                activeFileUri: activeNotebook.uri,
+                currentIntegrations,
+                integration,
+                notebookManager: this.notebookManager,
+                projectId
+            });
+
+            if (activePersisted) {
+                outcome = 'completed';
+                void window.showInformationMessage(
+                    localize.Integrations.addExistingIntegrationSucceeded(integration.name)
+                );
+
+                if (siblingsFailed > 0) {
+                    void window.showWarningMessage(
+                        l10n.t(
+                            'Integrations saved, but {0} related notebook file(s) could not be updated.',
+                            siblingsFailed
+                        )
+                    );
+                }
+
+                // Storage did not change, so the storage-change listeners that normally refresh kernels and the
+                // panel after a save stay silent; do both explicitly for this project.
+                await this.refreshAfterRosterChange(projectId, activeNotebook);
+            } else {
+                void window.showErrorMessage(localize.Integrations.addExistingIntegrationFailed);
+            }
+        } catch (error) {
+            logger.error(`IntegrationManager: failed to add existing integration ${integration.id}`, error);
+            void window.showErrorMessage(localize.Integrations.addExistingIntegrationFailed);
+        }
+
+        this.analytics.trackEvent({
+            eventName: 'add_existing_integration',
+            properties: { integrationType: integration.type, outcome }
+        });
+
+        return outcome;
     }
 
     /** The notebook URI a menu contribution passed; `notebook/toolbar` sends `{ notebookEditor: { notebookUri } }`. */
@@ -60,6 +205,39 @@ export class IntegrationManager implements IIntegrationManager {
         const uri = candidate.notebookEditor?.notebookUri ?? candidate.notebookUri;
 
         return uri ? String(uri) : undefined;
+    }
+
+    /** The project's roster as the notebook manager caches it, narrowed to the types the panel can manage. */
+    private getCachedRoster(projectId: string, notebookId: string): ProjectIntegration[] {
+        const project = this.notebookManager.getProjectForNotebook(projectId, notebookId);
+        const roster: ProjectIntegration[] = [];
+
+        for (const entry of project?.project.integrations ?? []) {
+            if (isConfigurableDatabaseIntegrationType(entry.type)) {
+                roster.push({ id: entry.id, name: entry.name, type: entry.type });
+            }
+        }
+
+        return roster;
+    }
+
+    /** Re-applies integration env in the project's running kernels and re-renders the panel with the new roster. */
+    private async refreshAfterRosterChange(projectId: string, activeNotebook: NotebookDocument): Promise<void> {
+        const projectNotebooks = workspace.notebookDocuments.filter(
+            (notebook) => notebook.notebookType === 'deepnote' && notebook.metadata?.deepnoteProjectId === projectId
+        );
+
+        try {
+            await this.liveRefresher?.refresh(projectNotebooks, 'integration_config');
+        } catch (error) {
+            logger.error('IntegrationManager: failed to refresh integration env after adding an integration', error);
+        }
+
+        try {
+            await this.showIntegrationsUI(undefined, activeNotebook.uri.toString());
+        } catch (error) {
+            logger.error('IntegrationManager: failed to refresh the integrations panel', error);
+        }
     }
 
     /**

--- a/src/notebooks/deepnote/integrations/integrationManager.unit.test.ts
+++ b/src/notebooks/deepnote/integrations/integrationManager.unit.test.ts
@@ -1,0 +1,239 @@
+import { deserializeDeepnoteFile, serializeDeepnoteFile, type DeepnoteFile } from '@deepnote/blocks';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { NotebookDocument, QuickPickItem, Uri, workspace } from 'vscode';
+
+import { ITelemetryService } from '../../../platform/analytics/types';
+import { IExtensionContext } from '../../../platform/common/types';
+import { ConfigurableDatabaseIntegrationConfig } from '../../../platform/notebooks/deepnote/integrationTypes';
+import { mockedVSCodeNamespaces, resetVSCodeMocks } from '../../../test/vscode-mock';
+import { IDeepnoteNotebookManager, ProjectIntegration } from '../../types';
+import {
+    createDeepnoteFile,
+    createDeepnoteProject,
+    createMockNotebook,
+    createWorkspaceFolder
+} from '../deepnoteTestHelpers';
+import { buildPostgresIntegration } from './federatedAuth/federatedAuthTestHelpers';
+import { IntegrationManager } from './integrationManager';
+import {
+    IIntegrationDetector,
+    IIntegrationEnvLiveRefresher,
+    IIntegrationStorage,
+    IIntegrationWebviewProvider
+} from './types';
+
+const CURRENT_PROJECT_ID = 'project-current';
+const CURRENT_NOTEBOOK_ID = 'notebook-current';
+const OTHER_PROJECT_ID = 'project-other';
+const CURRENT_URI = Uri.file('/ws/current.deepnote');
+const OTHER_URI = Uri.file('/ws/other.deepnote');
+
+const SHARED_CONFIG = buildPostgresIntegration({ id: 'pg-shared', name: 'Shared Postgres' });
+
+function projectFile(projectId: string, notebookId: string, integrations: ProjectIntegration[]): DeepnoteFile {
+    return createDeepnoteFile({
+        project: createDeepnoteProject({
+            id: projectId,
+            name: projectId,
+            notebooks: [{ id: notebookId, name: 'Notebook', blocks: [] }],
+            integrations
+        })
+    });
+}
+
+suite('IntegrationManager.addExistingIntegration', () => {
+    let currentNotebook: NotebookDocument;
+    let otherNotebook: NotebookDocument;
+    let currentProject: DeepnoteFile;
+    let writes: Map<string, DeepnoteFile>;
+    let cacheUpdates: ProjectIntegration[][];
+    let refreshSpy: sinon.SinonSpy;
+    let quickPickItems: QuickPickItem[] | undefined;
+
+    let detector: IIntegrationDetector;
+    let webviewProvider: IIntegrationWebviewProvider;
+    let notebookManager: IDeepnoteNotebookManager;
+    let telemetry: ITelemetryService;
+    let storedConfigs: ConfigurableDatabaseIntegrationConfig[];
+    let onDiskOther: DeepnoteFile | undefined;
+
+    setup(() => {
+        resetVSCodeMocks();
+
+        currentNotebook = createMockNotebook({
+            uri: CURRENT_URI,
+            metadata: { deepnoteProjectId: CURRENT_PROJECT_ID, deepnoteNotebookId: CURRENT_NOTEBOOK_ID }
+        });
+        otherNotebook = createMockNotebook({
+            uri: OTHER_URI,
+            metadata: { deepnoteProjectId: OTHER_PROJECT_ID, deepnoteNotebookId: 'notebook-other' }
+        });
+        currentProject = projectFile(CURRENT_PROJECT_ID, CURRENT_NOTEBOOK_ID, []);
+        onDiskOther = projectFile(OTHER_PROJECT_ID, 'notebook-other', [
+            { id: SHARED_CONFIG.id, name: SHARED_CONFIG.name, type: SHARED_CONFIG.type }
+        ]);
+        storedConfigs = [SHARED_CONFIG];
+        writes = new Map();
+        cacheUpdates = [];
+        quickPickItems = undefined;
+
+        when(mockedVSCodeNamespaces.workspace.workspaceFolders).thenReturn([createWorkspaceFolder(Uri.file('/ws'))]);
+        when(mockedVSCodeNamespaces.workspace.notebookDocuments).thenReturn([currentNotebook, otherNotebook]);
+        when(mockedVSCodeNamespaces.workspace.findFiles(anything())).thenCall(() =>
+            Promise.resolve(onDiskOther ? [CURRENT_URI, OTHER_URI] : [CURRENT_URI])
+        );
+
+        const mockFs = mock<typeof workspace.fs>();
+        when(mockFs.readFile(anything())).thenCall((uri: Uri) => {
+            const file = uri.fsPath === CURRENT_URI.fsPath ? currentProject : onDiskOther;
+
+            return file
+                ? Promise.resolve(new TextEncoder().encode(serializeDeepnoteFile(file)))
+                : Promise.reject(new Error(`no readFile stub for ${uri.fsPath}`));
+        });
+        when(mockFs.writeFile(anything(), anything())).thenCall((uri: Uri, bytes: Uint8Array) => {
+            writes.set(uri.fsPath, deserializeDeepnoteFile(new TextDecoder().decode(bytes)));
+
+            return Promise.resolve();
+        });
+        when(mockedVSCodeNamespaces.workspace.fs).thenReturn(instance(mockFs));
+
+        // Picks the first offered item; tests that want a cancel override this.
+        when(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).thenCall((items: QuickPickItem[]) => {
+            quickPickItems = items;
+
+            return Promise.resolve(items[0]);
+        });
+
+        const mockDetector = mock<IIntegrationDetector>();
+        when(mockDetector.detectIntegrations(anything())).thenResolve(new Map());
+        detector = mockDetector;
+
+        webviewProvider = mock<IIntegrationWebviewProvider>();
+        when(webviewProvider.show(anything(), anything(), anything(), anything(), anything())).thenResolve();
+
+        const mockManager = mock<IDeepnoteNotebookManager>();
+        when(mockManager.getProjectForNotebook(CURRENT_PROJECT_ID, CURRENT_NOTEBOOK_ID)).thenCall(() => currentProject);
+        when(mockManager.updateProjectIntegrations(anything(), anything())).thenCall(
+            (_projectId: string, integrations: ProjectIntegration[]) => {
+                cacheUpdates.push(integrations);
+
+                return true;
+            }
+        );
+        notebookManager = mockManager;
+
+        telemetry = mock<ITelemetryService>();
+        refreshSpy = sinon.spy(async () => undefined);
+    });
+
+    function buildManager(): IntegrationManager {
+        const extensionContext = mock<IExtensionContext>();
+        when(extensionContext.subscriptions).thenReturn([]);
+
+        const storage = mock<IIntegrationStorage>();
+        when(storage.getIntegrationConfig(anything())).thenCall((id: string) =>
+            Promise.resolve(storedConfigs.find((config) => config.id === id))
+        );
+
+        const liveRefresher: IIntegrationEnvLiveRefresher = { refresh: refreshSpy };
+
+        return new IntegrationManager(
+            instance(extensionContext),
+            instance(detector),
+            instance(storage),
+            instance(webviewProvider),
+            instance(notebookManager),
+            instance(telemetry),
+            liveRefresher
+        );
+    }
+
+    test("links the picked integration into the roster, refreshes only this project's kernels and re-shows the panel", async () => {
+        const outcome = await buildManager().addExistingIntegration(CURRENT_URI.toString());
+
+        assert.strictEqual(outcome, 'completed');
+
+        const expectedRoster: ProjectIntegration[] = [{ id: 'pg-shared', name: 'Shared Postgres', type: 'pgsql' }];
+        assert.deepStrictEqual(writes.get(CURRENT_URI.fsPath)?.project.integrations, expectedRoster);
+        assert.deepStrictEqual(cacheUpdates, [expectedRoster]);
+        assert.isUndefined(writes.get(OTHER_URI.fsPath), 'the other project must not be rewritten');
+
+        assert.isTrue(refreshSpy.calledOnce);
+        assert.deepStrictEqual(refreshSpy.firstCall.args, [[currentNotebook], 'integration_config']);
+
+        verify(webviewProvider.show(CURRENT_PROJECT_ID, anything(), anything(), anything(), anything())).once();
+
+        verify(
+            telemetry.trackEvent(
+                deepEqual({
+                    eventName: 'add_existing_integration',
+                    properties: { integrationType: 'pgsql', outcome: 'completed' }
+                })
+            )
+        ).once();
+
+        assert.strictEqual(quickPickItems?.length, 1);
+        assert.strictEqual(quickPickItems?.[0].label, 'Shared Postgres');
+        assert.strictEqual(quickPickItems?.[0].description, 'PostgreSQL');
+        assert.strictEqual(quickPickItems?.[0].detail, `Used in: ${OTHER_PROJECT_ID}`);
+    });
+
+    test('shows an information message and writes nothing when no other project has a reusable integration', async () => {
+        onDiskOther = undefined;
+
+        const outcome = await buildManager().addExistingIntegration(CURRENT_URI.toString());
+
+        assert.strictEqual(outcome, 'completed');
+        assert.strictEqual(writes.size, 0);
+        assert.deepStrictEqual(cacheUpdates, []);
+        assert.isTrue(refreshSpy.notCalled);
+        verify(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).never();
+        verify(mockedVSCodeNamespaces.window.showInformationMessage(anything())).once();
+    });
+
+    test('does not offer an integration the current project already has', async () => {
+        currentProject = projectFile(CURRENT_PROJECT_ID, CURRENT_NOTEBOOK_ID, [
+            { id: SHARED_CONFIG.id, name: SHARED_CONFIG.name, type: SHARED_CONFIG.type }
+        ]);
+
+        await buildManager().addExistingIntegration(CURRENT_URI.toString());
+
+        assert.strictEqual(writes.size, 0);
+        verify(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).never();
+    });
+
+    test('warns and offers nothing when the only candidate is declared with a type the stored config does not match', async () => {
+        onDiskOther = projectFile(OTHER_PROJECT_ID, 'notebook-other', [
+            { id: SHARED_CONFIG.id, name: SHARED_CONFIG.name, type: 'mysql' }
+        ]);
+
+        await buildManager().addExistingIntegration(CURRENT_URI.toString());
+
+        assert.strictEqual(writes.size, 0);
+        verify(mockedVSCodeNamespaces.window.showWarningMessage(anything())).once();
+        verify(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).never();
+    });
+
+    test('returns cancelled and writes nothing when the picker is dismissed', async () => {
+        when(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).thenResolve(undefined);
+
+        const outcome = await buildManager().addExistingIntegration(CURRENT_URI.toString());
+
+        assert.strictEqual(outcome, 'cancelled');
+        assert.strictEqual(writes.size, 0);
+        assert.isTrue(refreshSpy.notCalled);
+        verify(telemetry.trackEvent(anything())).never();
+    });
+
+    test('fails without a Deepnote notebook to act on', async () => {
+        when(mockedVSCodeNamespaces.workspace.notebookDocuments).thenReturn([]);
+
+        const outcome = await buildManager().addExistingIntegration(Uri.file('/ws/missing.deepnote').toString());
+
+        assert.strictEqual(outcome, 'failed');
+        verify(mockedVSCodeNamespaces.window.showErrorMessage(anything())).once();
+    });
+});

--- a/src/notebooks/deepnote/integrations/integrationManager.unit.test.ts
+++ b/src/notebooks/deepnote/integrations/integrationManager.unit.test.ts
@@ -16,6 +16,7 @@ import {
     createWorkspaceFolder
 } from '../deepnoteTestHelpers';
 import { buildPostgresIntegration } from './federatedAuth/federatedAuthTestHelpers';
+import { RawProjectIntegration } from './existingIntegrationPicker';
 import { IntegrationManager } from './integrationManager';
 import {
     IIntegrationDetector,
@@ -32,7 +33,7 @@ const OTHER_URI = Uri.file('/ws/other.deepnote');
 
 const SHARED_CONFIG = buildPostgresIntegration({ id: 'pg-shared', name: 'Shared Postgres' });
 
-function projectFile(projectId: string, notebookId: string, integrations: ProjectIntegration[]): DeepnoteFile {
+function projectFile(projectId: string, notebookId: string, integrations: RawProjectIntegration[]): DeepnoteFile {
     return createDeepnoteFile({
         project: createDeepnoteProject({
             id: projectId,
@@ -192,6 +193,24 @@ suite('IntegrationManager.addExistingIntegration', () => {
         assert.isTrue(refreshSpy.notCalled);
         verify(mockedVSCodeNamespaces.window.showQuickPick(anything(), anything())).never();
         verify(mockedVSCodeNamespaces.window.showInformationMessage(anything())).once();
+    });
+
+    test('keeps roster entries the panel cannot manage (pandas-dataframe) when attaching', async () => {
+        currentProject = projectFile(CURRENT_PROJECT_ID, CURRENT_NOTEBOOK_ID, [
+            { id: 'duckdb', name: 'DuckDB', type: 'pandas-dataframe' }
+        ]);
+
+        const outcome = await buildManager().addExistingIntegration(CURRENT_URI.toString());
+
+        assert.strictEqual(outcome, 'completed');
+
+        const expectedRoster = [
+            { id: 'duckdb', name: 'DuckDB', type: 'pandas-dataframe' },
+            { id: 'pg-shared', name: 'Shared Postgres', type: 'pgsql' }
+        ];
+        assert.deepStrictEqual(writes.get(CURRENT_URI.fsPath)?.project.integrations, expectedRoster);
+        assert.deepStrictEqual(cacheUpdates, [expectedRoster]);
+        assert.strictEqual(quickPickItems?.length, 1, 'the DuckDB entry is neither offered nor a candidate');
     });
 
     test('does not offer an integration the current project already has', async () => {

--- a/src/notebooks/deepnote/integrations/integrationWebview.ts
+++ b/src/notebooks/deepnote/integrations/integrationWebview.ts
@@ -171,6 +171,7 @@ export class IntegrationWebviewProvider implements IIntegrationWebviewProvider {
             integrationsConfirmDeleteDetails: localize.Integrations.confirmDeleteDetails,
             integrationsConfigureTitle: localize.Integrations.configureTitle,
             integrationsAddNewIntegration: localize.Integrations.addNewIntegration,
+            integrationsAddExistingIntegration: localize.Integrations.addExistingIntegration,
             integrationsDatabase: localize.Integrations.database,
             integrationsDataWarehousesLakes: localize.Integrations.dataWarehousesLakes,
             integrationsDatabases: localize.Integrations.databases,
@@ -742,6 +743,16 @@ export class IntegrationWebviewProvider implements IIntegrationWebviewProvider {
             case 'signOut':
                 if (message.integrationId) {
                     await this.signOutIntegration(message.integrationId);
+                }
+                break;
+            case 'addExisting':
+                // The command owns the QuickPick and the roster write, and re-shows this panel with the new roster.
+                try {
+                    await commands.executeCommand(Commands.AddExistingIntegration, {
+                        notebookUri: this.activeFileUri?.toString()
+                    });
+                } catch (error) {
+                    logger.error('IntegrationWebviewProvider: AddExistingIntegration command failed', error);
                 }
                 break;
             case 'authenticate':

--- a/src/notebooks/deepnote/integrations/integrationWebview.unit.test.ts
+++ b/src/notebooks/deepnote/integrations/integrationWebview.unit.test.ts
@@ -517,6 +517,25 @@ suite('IntegrationWebviewProvider', () => {
         );
     });
 
+    test('handleMessage: "addExisting" → executeCommand(AddExistingIntegration, { notebookUri }) for the active file', async () => {
+        const executeCommandStub = sinon.stub().resolves(undefined);
+        when(mockedVSCodeNamespaces.commands.executeCommand(anyString(), anything())).thenCall((command, arg) =>
+            executeCommandStub(command, arg)
+        );
+
+        const provider = buildProvider();
+        await show(provider, new Map());
+
+        await fakePanel.onDidReceiveMessage({ type: 'addExisting' });
+
+        assert.isTrue(
+            executeCommandStub.calledOnceWithExactly(Commands.AddExistingIntegration, {
+                notebookUri: ACTIVE_FILE_URI.toString()
+            }),
+            "expected the command to receive the panel's active notebook so the picker targets the same project"
+        );
+    });
+
     suite('handleMessage: "authenticate" telemetry outcome', () => {
         async function authenticate(commandResult: Promise<unknown>): Promise<void> {
             when(mockedVSCodeNamespaces.commands.executeCommand(anyString(), anything(), anything())).thenReturn(

--- a/src/platform/analytics/types.ts
+++ b/src/platform/analytics/types.ts
@@ -12,6 +12,7 @@ export type TelemetryEventName =
     | 'delete_integration'
     | 'delete_notebook'
     | 'duplicate_notebook'
+    | 'add_existing_integration'
     | 'execute_cell'
     | 'execute_notebook'
     | 'export_notebook'
@@ -57,6 +58,8 @@ export interface TelemetryEventProperties {
      * No `outcome`: nothing here is a command the user waits on — there is no progress UI and no cancel, so
      * `'cancelled'` is unreachable and a partial pass has no defensible single value. The counts carry it.
      */
+    /** A SecretStorage integration from another project in the workspace was linked into this project's roster. */
+    add_existing_integration: { integrationType: string; outcome: CommandOutcome };
     refresh_integration_env: {
         /** Notebooks the refresh ran over, including ones skipped for having no started kernel. */
         attemptedCount: number;

--- a/src/platform/common/constants.ts
+++ b/src/platform/common/constants.ts
@@ -225,6 +225,7 @@ export namespace Commands {
     export const CopyNotebookDetails = 'deepnote.copyNotebookDetails';
     export const EnableSnapshots = 'deepnote.enableSnapshots';
     export const DisableSnapshots = 'deepnote.disableSnapshots';
+    export const AddExistingIntegration = 'deepnote.addExistingIntegration';
     export const AuthenticateIntegration = 'deepnote.authenticateIntegration';
     export const ManageIntegrations = 'deepnote.manageIntegrations';
     export const AddAgentBlock = 'deepnote.addAgentBlock';

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -837,6 +837,24 @@ export namespace Integrations {
     export const cancel = l10n.t('Cancel');
     export const save = l10n.t('Save');
     export const addNewIntegration = l10n.t('Add New Integration');
+    export const addExistingIntegration = l10n.t('Add Existing Integration');
+    export const addExistingIntegrationPlaceholder = l10n.t(
+        'Select an integration configured in another project of this workspace'
+    );
+    export const addExistingIntegrationNoneAvailable = l10n.t(
+        'No integrations from other projects in this workspace are available to add. Integrations configured only in .deepnote.env.yaml already apply to every project under it.'
+    );
+    export const addExistingIntegrationConflictsSkipped = (count: number) =>
+        l10n.t(
+            '{0} integration(s) were skipped because another project declares them with a different type than the stored configuration.',
+            count
+        );
+    export const addExistingIntegrationSucceeded = (integrationName: string) =>
+        l10n.t('Added integration "{0}" to this project.', integrationName);
+    export const addExistingIntegrationFailed = l10n.t(
+        'Failed to add the integration to the notebook file. Please try again.'
+    );
+    export const addExistingIntegrationUsedIn = (projectNames: string) => l10n.t('Used in: {0}', projectNames);
     export const database = l10n.t('Database');
     export const dataWarehousesLakes = l10n.t('Data Warehouses & Lakes');
     export const databases = l10n.t('Databases');

--- a/src/webviews/webview-side/integrations/IntegrationPanel.tsx
+++ b/src/webviews/webview-side/integrations/IntegrationPanel.tsx
@@ -212,6 +212,10 @@ export const IntegrationPanel: React.FC<IIntegrationPanelProps> = ({ baseTheme, 
         setSelectedIntegrationType(undefined);
     };
 
+    const handleAddExisting = () => {
+        postOutbound({ type: 'addExisting' });
+    };
+
     const handleSelectIntegrationType = (type: ConfigurableDatabaseIntegrationType) => {
         // Generate a new UUID for the integration
         const newId = generateUuid();
@@ -239,7 +243,7 @@ export const IntegrationPanel: React.FC<IIntegrationPanelProps> = ({ baseTheme, 
                 onSignOut={handleSignOut}
             />
 
-            <IntegrationTypeSelector onSelectType={handleSelectIntegrationType} />
+            <IntegrationTypeSelector onAddExisting={handleAddExisting} onSelectType={handleSelectIntegrationType} />
 
             {selectedIntegrationId && selectedIntegrationType && (
                 <ConfigurationForm

--- a/src/webviews/webview-side/integrations/IntegrationTypeSelector.tsx
+++ b/src/webviews/webview-side/integrations/IntegrationTypeSelector.tsx
@@ -4,6 +4,8 @@ import { ConfigurableDatabaseIntegrationType } from './types';
 import { integrationTypeLabels, integrationTypeIcons } from './integrationUtils';
 
 export interface IIntegrationTypeSelectorProps {
+    /** Opens the extension-side picker of integrations other projects in the workspace already configured. */
+    onAddExisting: () => void;
     onSelectType: (type: ConfigurableDatabaseIntegrationType) => void;
 }
 
@@ -111,10 +113,15 @@ const DATABASE_INTEGRATION_TYPES: IntegrationTypeInfo[] = [
     }
 ];
 
-export const IntegrationTypeSelector: React.FC<IIntegrationTypeSelectorProps> = ({ onSelectType }) => {
+export const IntegrationTypeSelector: React.FC<IIntegrationTypeSelectorProps> = ({ onAddExisting, onSelectType }) => {
     return (
         <div className="integration-type-selector">
-            <h2>{getLocString('integrationsAddNewIntegration', 'Add New Integration')}</h2>
+            <div className="integration-type-selector-header">
+                <h2>{getLocString('integrationsAddNewIntegration', 'Add New Integration')}</h2>
+                <button type="button" className="secondary" onClick={onAddExisting}>
+                    {getLocString('integrationsAddExistingIntegration', 'Add Existing Integration')}
+                </button>
+            </div>
 
             <div className="integration-type-section">
                 <h3 className="integration-type-section-title">

--- a/src/webviews/webview-side/integrations/integrations.css
+++ b/src/webviews/webview-side/integrations/integrations.css
@@ -329,9 +329,16 @@ form {
     border-top: 1px solid var(--vscode-panel-border);
 }
 
-.integration-type-selector h2 {
-    margin-top: 0;
+.integration-type-selector-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
     margin-bottom: 24px;
+}
+
+.integration-type-selector h2 {
+    margin: 0;
     font-size: 1.2em;
     font-weight: 600;
 }

--- a/src/webviews/webview-side/integrations/types.ts
+++ b/src/webviews/webview-side/integrations/types.ts
@@ -62,4 +62,5 @@ export type WebviewOutboundMessage =
     | { type: 'reset'; integrationId: string }
     | { type: 'delete'; integrationId: string }
     | { type: 'signOut'; integrationId: string }
+    | { type: 'addExisting' }
     | AuthenticateMessage;

--- a/test/e2e/suite/workspace/integrations.e2e.test.ts
+++ b/test/e2e/suite/workspace/integrations.e2e.test.ts
@@ -24,6 +24,9 @@ const WEBVIEW_READ_TIMEOUT = 15_000;
 // Empty-state text asserted to prove the panel actually opened (else the negative `not.contain`
 // below passes trivially against a blank/failed `''` read).
 const NO_INTEGRATIONS_TEXT = 'No integrations found in this project.';
+// The "Add Existing Integration" entry point (reuse an integration another project configured) must render in
+// the panel regardless of whether this project has integrations of its own.
+const ADD_EXISTING_INTEGRATION_TEXT = 'Add Existing Integration';
 // Prior editors finish closing before reopening the target notebook.
 const EDITORS_CLOSE_DELAY = 500;
 // Freshly opened notebook paints before we refocus it.
@@ -126,5 +129,6 @@ describe('Deepnote — the integrations UI', function () {
         // Positive signal that the panel rendered (a blank read would make `not.contain` pass trivially).
         expect(text, 'integrations webview text').to.contain(NO_INTEGRATIONS_TEXT);
         expect(text, 'integrations webview text').to.not.contain(INTEGRATION_NAME);
+        expect(text, 'integrations webview text').to.contain(ADD_EXISTING_INTEGRATION_TEXT);
     });
 });


### PR DESCRIPTION
## Summary

Implements the smaller shape from #276 ("Add existing integration"): a project can link an integration that another project in the same workspace already configured through the UI, instead of re-entering and re-storing the same credentials.

The `.deepnote.env.yaml` route from #440 is untouched; this only covers UI/SecretStorage-created integrations.

## What the user sees

- **Manage Integrations panel**: an "Add Existing Integration" button next to the "Add New Integration" heading.
- **Command palette**: `Deepnote: Add Existing Integration` (`deepnote.addExistingIntegration`), acting on the active Deepnote notebook the same way `Manage Integrations` does.
- A QuickPick lists integrations declared by *other* projects in the workspace that have a stored config: label = name, description = type (e.g. PostgreSQL), detail = `Used in: <project names>`. Entries already on this project's roster are excluded; duplicates across projects collapse into one row.
- Picking one adds it to the project, shows a confirmation, refreshes integration env in the project's running kernels, and re-opens the panel with the new row.
- Edge cases: nothing available → information message (pointing at `.deepnote.env.yaml` for file-only setups); an id whose roster type disagrees with the stored config's type → skipped with a warning; write failure → error message.

## Storage / attach design

`IntegrationStorage` keys configs by integration id alone (`deepnote-integrations/<id>`); there is no per-project namespace, and `getProjectIntegrationConfig` ignores `projectId`. Both the env-var provider and the detector resolve credentials from the project roster (`project.integrations[].id`) in the `.deepnote` file. The roster entry is therefore the only thing that scopes an integration to a project.

So "attach" is a pure **link**: the command appends `{ id, name, type }` to the project's roster through the existing `persistProjectIntegrations` writer (cache + active file + sibling files), and nothing is copied or re-keyed in SecretStorage. This is the least invasive option and it matches the issue's intent — the two projects share one config, so editing it in either panel updates both.

**Federated-auth (BigQuery `google-oauth`) integrations are included.** `FederatedAuthTokenStorage` is also keyed by integration id, and the per-cell code generator resolves the config through the roster of the notebook being run, so a linked project reuses the same refresh token without re-authenticating. Documented in a code comment on `collectReusableIntegrations`.

Because storage does not change, the `onDidChangeIntegrations` listeners that normally refresh kernels and the panel after a save stay silent; the command calls `IIntegrationEnvLiveRefresher.refresh` for the project's notebooks (node only; `@optional` on web) and re-shows the panel explicitly.

Candidates are enumerated by scanning `.deepnote` files in the workspace folders (same `findFiles` pattern as the writer, snapshots skipped) rather than the notebook manager's cache, so closed projects are offered too.

The command is registered inside the existing `IntegrationManager.activate()`; no new service was added to `serviceRegistry.node.ts`, and nothing under `src/kernels/deepnote/`, `src/platform/interpreter/` or `vscodeNotebookController.ts` is touched.

Closes #276

## Testing

- `npm run compile-tsc` — pass
- `npm run typecheck` — pass
- `npm run esbuild-all` — pass (webview bundle includes the new button)
- `npm run lint` (oxlint) — pass (only pre-existing warnings in unrelated files)
- `npm run format` (prettier) — pass
- `npm run spell-check` — pass
- `npm run compile-e2e` — pass
- Unit tests: full suite run (`npm test`) — 2787 passing, 1 failing: `DeepnoteKernelAutoSelector - rebuildController › ensureKernelSelected › should return false and remove mapping when environment is not found` timed out at 2000 ms under full-suite load. That file (`src/kernels/deepnote/`) is not touched here; re-run in isolation it passes (45 passing).
- New/changed suites (17 tests) pass: `existingIntegrationPicker.unit.test.ts` (listing, dedupe, exclusion, file-only/unsupported skip, type-conflict skip, snapshot/unreadable handling, attach write), `integrationManager.unit.test.ts` (happy path incl. roster write, kernel refresh scoped to the project, panel re-show, telemetry; none available; already attached; conflict warning; cancel; no notebook), and an `addExisting` message test in `integrationWebview.unit.test.ts`.
- E2E: added one assertion to the existing `workspace/integrations.e2e.test.ts` that the "Add Existing Integration" entry point renders in the panel. A full picker e2e would need a way to seed SecretStorage with a configured integration in the test workspace, which the current harness doesn't have, so the QuickPick flow is covered by unit tests only. The e2e suite was **not run locally** (needs `npm run setup:e2e`); only compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “Add Existing Integration” action to the integrations panel.
  - Select compatible integrations from other workspace projects without copying credentials.
  - Added status messages for availability, conflicts, successful additions, and failures.
  - Integration changes now refresh the relevant environment and panel automatically.

- **Testing**
  - Added unit and end-to-end coverage for discovery, selection, conflicts, persistence, refreshes, and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->