### PR TITLE
fix(build): make npm ci work on arm64 Macs by making zeromqold optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,3 +269,39 @@ jobs:
 
       - name: Run audit for all dependencies
         run: npx better-npm-audit audit
+
+  build-without-optional-deps:
+    name: Build without optional deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies without optional packages
+        run: |
+          # Simulates an arm64 Mac, where npm drops the optional `zeromqold` fallback because it
+          # has no darwin-arm64 prebuild and cannot be compiled without cmake and Python distutils.
+          npm ci --omit=optional --prefer-offline --no-audit
+          # The Tailwind and lightningcss native binaries are optional too, but the bundle needs them.
+          # Restore only those, still omitting the rest, without touching package.json or the lockfile.
+          npm install --omit=optional --no-save --no-audit \
+            "lightningcss-linux-x64-gnu@$(node -p "require('./package.json').optionalDependencies['lightningcss-linux-x64-gnu']")" \
+            "@tailwindcss/oxide-linux-x64-gnu@$(node -p "require('./package.json').optionalDependencies['@tailwindcss/oxide-linux-x64-gnu']")"
+          test ! -e node_modules/zeromqold
+
+      - name: Build extension bundle
+        run: npm run esbuild-all
+
+      - name: Verify bundle
+        run: |
+          test -f dist/node_modules/zeromq/prebuilds/linux-x64/node.napi.glibc.node
+          test ! -e dist/node_modules/zeromqold

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,8 +270,8 @@ jobs:
       - name: Run audit for all dependencies
         run: npx better-npm-audit audit
 
-  build-without-optional-deps:
-    name: Build without optional deps
+  build-without-zeromqold:
+    name: Build without zeromqold
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -286,17 +286,13 @@ jobs:
           cache: 'npm'
           node-version-file: '.nvmrc'
 
-      - name: Install dependencies without optional packages
+      - name: Install dependencies and drop the optional zeromqold fallback
         run: |
-          # Simulates an arm64 Mac, where npm drops the optional `zeromqold` fallback because it
-          # has no darwin-arm64 prebuild and cannot be compiled without cmake and Python distutils.
-          npm ci --omit=optional --prefer-offline --no-audit
-          # The Tailwind and lightningcss native binaries are optional too, but the bundle needs them.
-          # Restore only those, still omitting the rest, without touching package.json or the lockfile.
-          npm install --omit=optional --no-save --no-audit \
-            "lightningcss-linux-x64-gnu@$(node -p "require('./package.json').optionalDependencies['lightningcss-linux-x64-gnu']")" \
-            "@tailwindcss/oxide-linux-x64-gnu@$(node -p "require('./package.json').optionalDependencies['@tailwindcss/oxide-linux-x64-gnu']")"
-          test ! -e node_modules/zeromqold
+          npm ci --prefer-offline --no-audit
+          # Reproduce the node_modules an arm64 Mac ends up with: npm drops the optional `zeromqold`
+          # there because it has no darwin-arm64 prebuild and cannot be compiled without cmake and
+          # Python distutils. Every other dependency installs normally.
+          rm -rf node_modules/zeromqold
 
       - name: Build extension bundle
         run: npm run esbuild-all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,22 +41,13 @@ Extensions: Show Recommended Extensions
 
 Then install all the extensions listed under "Workspace Recommendations".
 
-On Apple Silicon, you will have to use system versions of `libsodium` and `libzmq` instead of the bundled ones. Also, you'll need to use Python 3.11 or older.
+No native toolchain is needed on Apple Silicon. `zeromq` ships a darwin-arm64 prebuild, and the
+legacy `zeromqold` fallback is an optional dependency: it has no arm64 prebuild and compiling it
+needs cmake plus a Python with `distutils`, so npm skips it when the build fails. The extension
+only loads `zeromqold` if `zeromq` fails to load, and the published `.vsix` is built on Linux
+where it installs normally, so a local build without it is fine.
 
-```shell
-brew update
-brew install cmake pkg-config libsodium zeromq
-
-export CMAKE_POLICY_VERSION_MINIMUM=3.5
-export PKG_CONFIG_PATH="$(brew --prefix)/lib/pkgconfig"
-export CPPFLAGS="-I$(brew --prefix libsodium)/include -I$(brew --prefix zeromq)/include"
-export LDFLAGS="-L$(brew --prefix libsodium)/lib -L$(brew --prefix zeromq)/lib"
-
-npm_config_build_from_source=true npm install zeromq@
-
-```
-
-Install the dependecies:
+Install the dependencies:
 
 ```shell
 npm install

--- a/build/esbuild/build.ts
+++ b/build/esbuild/build.ts
@@ -570,9 +570,22 @@ async function copyZeroMQ() {
         filter: (src) => shouldCopyFileFromZmqFolder(src)
     });
 }
+/**
+ * `zeromqold` is an optional dependency: it ships no darwin-arm64 prebuild and compiling it from
+ * source needs cmake plus a Python with distutils, so npm skips it on Apple Silicon.
+ * The extension only uses it as a runtime fallback when `zeromq` fails to load, so a build
+ * without it is still valid on the machine that produced it.
+ */
 async function copyZeroMQOld() {
     const source = path.join(extensionFolder, 'node_modules', 'zeromqold');
     const target = path.join(extensionFolder, 'dist', 'node_modules', 'zeromqold');
+    if (!(await fs.pathExists(source))) {
+        console.warn(
+            colors.yellow(`Warning: optional dependency zeromqold not found at ${source}. `) +
+                colors.yellow('Skipping copy; the zeromq fallback binary will not be bundled.')
+        );
+        return;
+    }
     await fs.ensureDir(path.dirname(target));
     await fs.ensureDir(target);
     await fs.copy(source, target, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,6 @@
                 "vscode-tas-client": "^0.1.84",
                 "ws": "^6.2.4",
                 "zeromq": "^6.5.0",
-                "zeromqold": "npm:zeromq@^6.0.0-beta.6",
                 "zod": "^4.1.12"
             },
             "devDependencies": {
@@ -245,7 +244,8 @@
             "optionalDependencies": {
                 "@tailwindcss/oxide-linux-x64-gnu": "4.1.14",
                 "fsevents": "^2.3.2",
-                "lightningcss-linux-x64-gnu": "1.30.1"
+                "lightningcss-linux-x64-gnu": "1.30.1",
+                "zeromqold": "npm:zeromq@^6.0.0-beta.6"
             }
         },
         "build/eslint-rules": {
@@ -34443,6 +34443,7 @@
             "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.6.tgz",
             "integrity": "sha512-wLf6M7pBHijl+BRltUL2VoDpgbQcOZetiX8UzycHL8CcYFxYnRrpoG5fi3UX3+Umavz1lk4/dGaQez8qiDgr/Q==",
             "hasInstallScript": true,
+            "optional": true,
             "dependencies": {
                 "node-gyp-build": "^4.1.0"
             },
@@ -58885,6 +58886,7 @@
             "version": "npm:zeromq@6.0.0-beta.6",
             "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.6.tgz",
             "integrity": "sha512-wLf6M7pBHijl+BRltUL2VoDpgbQcOZetiX8UzycHL8CcYFxYnRrpoG5fi3UX3+Umavz1lk4/dGaQez8qiDgr/Q==",
+            "optional": true,
             "requires": {
                 "node-gyp-build": "^4.1.0"
             }

--- a/package.json
+++ b/package.json
@@ -2800,7 +2800,6 @@
         "vscode-tas-client": "^0.1.84",
         "ws": "^6.2.4",
         "zeromq": "^6.5.0",
-        "zeromqold": "npm:zeromq@^6.0.0-beta.6",
         "zod": "^4.1.12"
     },
     "devDependencies": {
@@ -2946,7 +2945,8 @@
     "optionalDependencies": {
         "@tailwindcss/oxide-linux-x64-gnu": "4.1.14",
         "fsevents": "^2.3.2",
-        "lightningcss-linux-x64-gnu": "1.30.1"
+        "lightningcss-linux-x64-gnu": "1.30.1",
+        "zeromqold": "npm:zeromq@^6.0.0-beta.6"
     },
     "overrides": {
         "braces": "3.0.3",


### PR DESCRIPTION
## Problem

On Apple Silicon, `npm ci` fails inside `zeromqold` (`zeromq@6.0.0-beta.6`). The package ships no `darwin-arm64` prebuild, so `node-gyp-build` falls back to compiling from source. That needs cmake and a Python with `distutils`, which Python 3.12 no longer has:

```
npm error path .../node_modules/zeromqold
npm error command sh -c node-gyp-build
npm error gyp info find Python using Python version 3.12.12
npm error     from distutils.version import StrictVersion
npm error ModuleNotFoundError: No module named 'distutils'
```

`zeromq@6.5.0` itself already ships an arm64 prebuild and its install script passes; the only failing package is the legacy fallback. Until now the workaround was to reuse an existing `node_modules`.

## Fix

- **`zeromqold` becomes an optional dependency.** npm skips an optional dependency whose install fails instead of failing the whole install. `node-gyp-build` stays a required dev dependency because `bufferutil` and `utf-8-validate` use it.
- **The esbuild build tolerates its absence.** `copyZeroMQOld` logs a warning and skips the copy into `dist/node_modules/zeromqold` when the package is not installed, using the same pattern as the existing `copyBundleIfExists` helper.
- **CONTRIBUTING.md** drops the stale Apple Silicon instructions (brew cmake/libsodium/zeromq, Python 3.11, build-from-source) and explains the new behaviour.

The runtime is unchanged: `getZeroMQ()` in `src/kernels/raw/session/zeromq.node.ts` already wraps the `zeromqold` require in a try/catch and only reaches it if `zeromq` fails to load. The published `.vsix` is built on `ubuntu-latest` in CI, where the `linux-x64` prebuild exists, so `zeromqold` is still bundled in releases.

## CI coverage

CI runs only on `ubuntu-latest`, where `zeromqold` has a prebuild, so no existing job exercised the path where npm drops it. A new **Build without zeromqold** job runs a normal `npm ci`, removes `node_modules/zeromqold` to reproduce the arm64 state, runs `npm run esbuild-all`, and asserts the bundle contains the `zeromq` prebuilds and no `zeromqold`. (`npm ci --omit=optional` was tried first, but it also drops the lightningcss and Tailwind native binaries the bundle needs, and they cannot be re-added while omitting optional deps because they are declared in `optionalDependencies`.)

## Verification (arm64 Mac, Node 22.21, Python 3.12, no cmake)

- `rm -rf node_modules && npm ci` exits 0 with no gyp output; `node_modules/zeromqold` is absent, `@vscode/zeromq` still populates `node_modules/zeromq/prebuilds/darwin-arm64`.
- `node -e "require('zeromq')"` loads (libzmq 4.3.5).
- `npx tsx build/esbuild/build.ts` exits 0 and prints the new warning for `zeromqold`; `dist/node_modules/zeromq/prebuilds` contains all seven platforms.
- `npm run spell-check` passes (it does not cover the changed files); `prettier --check` on `build/esbuild/build.ts` and `package.json` passes. `CONTRIBUTING.md` was already unformatted on `main` and this PR does not add new prettier findings there.
- Lockfile regenerated with `npm install --package-lock-only`; the only change is the `optional: true` flags on the two `zeromqold` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Apple Silicon setup instructions with the current native ZeroMQ prebuild process.
  * Added guidance for the optional fallback package and Linux-based extension builds.

* **Bug Fixes**
  * Builds no longer fail when the optional ZeroMQ fallback package is unavailable.
  * Added a warning to clarify when the fallback package is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->